### PR TITLE
[fix] attempt to fix trapping of thrown application errors by removing try catch to exit more gracefully

### DIFF
--- a/lib/channel.js
+++ b/lib/channel.js
@@ -185,7 +185,7 @@ C.toClosing = function(capturedStack, k) {
 };
 
 C._rejectPending = function() {
-  function rej(r) { 
+  function rej(r) {
     r(new Error("Channel ended, no reply will be forthcoming"));
   }
   if (this.reply !== null) rej(this.reply);
@@ -226,25 +226,36 @@ C.closeWithError = function(reason, code, error) {
 // Keep the try/catch localised, in an attempt to avoid disabling
 // optimisation
 C.acceptMessageFrame = function(f) {
-  try {
-    this.handleMessage = this.handleMessage(f);
-  }
-  catch (msg) {
-    if (typeof msg === 'string') {
-      this.closeWithError(msg, defs.constants.UNEXPECTED_FRAME,
-                          new Error(msg));
-    }
-    else if (msg instanceof Error) {
-      this.closeWithError('Error while processing message',
-                          defs.constants.INTERNAL_ERROR, msg);
-    }
-    else {
-      this.closeWithError('Internal error while processing message',
-                          defs.constants.INTERNAL_ERROR,
-                          new Error(msg.toString()));
-    }
+  var self = this;
+  //
+  // Remark: This means we are an EventEmitter and we are waiting to close gracefully
+  //
+  if (typeof this.handleMessage !== 'function') return;
+
+  this.handleMessage = this.handleMessage(f);
+
+  if (typeof this.handleMessage !== 'function'
+     && this.handleMessage instanceof EventEmitter) {
+    this.handleMessage.once('close', function (type, error) {
+      if (type === 'unexpected-frame')
+        self.closeWithError(msg, defs.constants.UNEXPECTED_FRAME, error);
+      else
+        self.closeWithError('Internal error while processing message', defs.constants.INTERNAL_ERROR, error);
+    });
   }
 };
+
+//
+// Remark: Emit a close event asynchronously so a handler can be bound and we can end
+// gracefully without try catch trapping errors all crazy like
+//
+function emitCloseAndDie(type, error) {
+  var emitter = new EventEmitter();
+  setImmediate(function () {
+    emitter.emit('close', type, error)
+  });
+  return emitter;
+}
 
 // Kick off a message delivery given a BasicDeliver or BasicReturn
 // frame (BasicGet uses the RPC mechanism)
@@ -252,8 +263,7 @@ function acceptDeliveryOrReturn(f) {
   var event;
   if (f.id === defs.BasicDeliver) event = 'delivery';
   else if (f.id === defs.BasicReturn) event = 'return';
-  else throw fmt("Expected BasicDeliver or BasicReturn; got %s",
-                 inspect(f));
+  else return emitCloseAndDie(null, new Error(fmt("Expected BasicDeliver or BasicReturn; got %s", inspect(f))))
 
   var self = this;
   var fields = f.fields;
@@ -282,7 +292,7 @@ function acceptMessage(continuation) {
     if (f.id === defs.BasicProperties) {
       message.properties = f.fields;
       totalSize = remaining = f.size;
-      
+
       // for zero-length messages, content frames aren't required.
       if (totalSize === 0) {
         message.content = new Buffer(0);
@@ -290,11 +300,11 @@ function acceptMessage(continuation) {
         return acceptDeliveryOrReturn;
       }
       else {
-        return content;        
+        return content;
       }
     }
     else {
-      throw "Expected headers frame after delivery";
+      return emitCloseAndDie("unexpected-frame", new Error("Expected headers frame after delivery"));
     }
   }
 
@@ -316,8 +326,8 @@ function acceptMessage(continuation) {
         return acceptDeliveryOrReturn;
       }
       else if (remaining < 0) {
-        throw fmt("Too much content sent! Expected %d bytes",
-                  totalSize);
+        return emitCloseAndDie(null, new Error(fmt("Too much content sent! Expected %d bytes",
+                  totalSize)));
       }
       else {
         if (buffers !== null)
@@ -327,7 +337,7 @@ function acceptMessage(continuation) {
         return content;
       }
     }
-    else throw "Expected content frame after headers"
+    else return emitCloseAndDie(null, new Error("Expected content frame after headers"));
   }
 }
 


### PR DESCRIPTION
@squaremo this is my attempt to fix #123 but it currently fails a few tests that I'm having difficulty reasoning about. Would love your help here if you have a minute. This seems to be reasonable as I don't see there a case where there _needs_ to be a throw or a thrown error is bound to occur but I could be wrong.
