### PR TITLE
feat: getCh function to return channel ID

### DIFF
--- a/lib/channel.js
+++ b/lib/channel.js
@@ -450,6 +450,9 @@ C.onBufferDrain = function() {
   this.emit('drain');
 };
 
+C.getCh = function() {
+  return this.ch;
+}
 
 // This adds just a bit more stuff useful for the APIs, but not
 // low-level machinery.


### PR DESCRIPTION
This getter is to return ch value for better channel resource management by users.