### PR TITLE
Fix Heartbeat Intervals

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -520,12 +520,19 @@ C.checkRecv = function(intervalMs) {
 
 C.sendBytes = function(bytes) {
   this.timeLastSent = Date.now();
-  this.stream.write(bytes);
+  return this.stream.write(bytes);
 };
 
 C.sendHeartbeat = function() {
   console.log("Sending heartbeat");
-  return this.sendBytes(frame.HEARTBEAT_BUF);
+  var flushedBuffer = this.sendBytes(frame.HEARTBEAT_BUF);
+
+  if (!flushedBuffer) {
+    console.log("listening for drain");
+    this.socket.once("drain", console.log("drained"));
+  }
+
+  return flushedBuffer;
 };
 
 var encodeMethod = defs.encodeMethod;

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -15,7 +15,8 @@ var Duplex =
   require('stream').Duplex ||
   require('readable-stream/duplex');
 var EventEmitter = require('events').EventEmitter;
-var Heart = require('./heartbeat').Heart;
+var heartbeat = require('./heartbeat');
+var Heart = heartbeat.Heart;
 
 var methodName = require('./format').methodName;
 var closeMsg = require('./format').closeMessage;
@@ -46,7 +47,7 @@ function Connection(underlying) {
   // frames
   this.rest = Buffer.alloc(0);
   this.frameMax = constants.FRAME_MIN_SIZE;
-  this.sentSinceLastCheck = false;
+  this.timeLastSent = 0;
   this.recvSinceLastCheck = false;
 
   this.expectSocketClose = false;
@@ -502,20 +503,23 @@ C.step = function(cb) {
   recv();
 };
 
-C.checkSend = function() {
-  var check = this.sentSinceLastCheck;
-  this.sentSinceLastCheck = false;
-  return check;
+C.checkSend = function(intervalMs) {
+  var now = Date.now();
+  var heartbeatInterval = intervalMs / 2;
+  var timeToSendHeartbeat = this.timeLastSent + heartbeatInterval * 0.85; // a 15% buffer
+  var needToSendHeartbeat = timeToSendHeartbeat <= now;
+
+  return !needToSendHeartbeat;
 }
 
-C.checkRecv = function() {
+C.checkRecv = function(intervalMs) {
   var check = this.recvSinceLastCheck;
   this.recvSinceLastCheck = false;
   return check;
 }
 
 C.sendBytes = function(bytes) {
-  this.sentSinceLastCheck = true;
+  this.timeLastSent = Date.now();
   this.stream.write(bytes);
 };
 
@@ -528,7 +532,7 @@ var encodeProperties = defs.encodeProperties;
 
 C.sendMethod = function(channel, Method, fields) {
   var frame = encodeMethod(Method, channel, fields);
-  this.sentSinceLastCheck = true;
+  this.timeLastSent = Date.now();
   var buffer = this.channels[channel].buffer;
   return buffer.write(frame);
 };
@@ -544,7 +548,7 @@ C.sendMessage = function(channel,
   var pframe = encodeProperties(Properties, channel,
                                 content.length, props);
   var buffer = this.channels[channel].buffer;
-  this.sentSinceLastCheck = true;
+  this.timeLastSent = Date.now();
 
   var methodHeaderLen = mframe.length + pframe.length;
   var bodyLen = (content.length > 0) ?
@@ -593,7 +597,7 @@ C.sendContent = function(channel, body) {
     var bodyFrame = makeBodyFrame(channel, slice);
     writeResult = buffer.write(bodyFrame);
   }
-  this.sentSinceLastCheck = true;
+  this.timeLastSent = Date.now();
   return writeResult;
 };
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -30,6 +30,8 @@ var PassThrough = require('stream').PassThrough ||
 var IllegalOperationError = require('./error').IllegalOperationError;
 var stackCapture = require('./error').stackCapture;
 
+var debug = require('debug')('amqplib:connection');
+
 // High-water mark for channel write buffers, in 'objects' (which are
 // encoded frames as buffers).
 var DEFAULT_WRITE_HWM = 1024;
@@ -524,12 +526,12 @@ C.sendBytes = function(bytes) {
 };
 
 C.sendHeartbeat = function() {
-  console.log("Sending heartbeat");
+  debug('Sending heartbeat');
   var flushedBuffer = this.sendBytes(frame.HEARTBEAT_BUF);
 
   if (!flushedBuffer) {
-    console.log("listening for drain");
-    this.socket.once("drain", console.log("drained"));
+    debug('listening for drain');
+    this.socket.once('drain', () => debug('drained'));
   }
 
   return flushedBuffer;
@@ -629,6 +631,9 @@ C.recvFrame = function() {
   }
   else {
     this.rest = frame.rest;
+    if (frame.type === constants.FRAME_HEARTBEAT) {
+      debug('rx heartbeat!');
+    }
     return decodeFrame(frame);
   }
 };

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -524,6 +524,7 @@ C.sendBytes = function(bytes) {
 };
 
 C.sendHeartbeat = function() {
+  console.log("Sending heartbeat");
   return this.sendBytes(frame.HEARTBEAT_BUF);
 };
 

--- a/lib/heartbeat.js
+++ b/lib/heartbeat.js
@@ -85,5 +85,5 @@ Heart.prototype.clear = function() {
 
 Heart.prototype.runHeartbeat = function(check, fail) {
   // Have we seen activity?
-  if (!check()) fail();
+  if (!check(this.interval * module.exports.UNITS_TO_MS)) fail();
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amqplib",
-  "version": "0.5.3",
+  "version": "0.5.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -40,11 +40,23 @@
       "dev": true
     },
     "bitsyntax": {
-      "version": "0.0.4",
-      "resolved": "http://npm.tescloud.com/bitsyntax/-/bitsyntax-0.0.4.tgz",
-      "integrity": "sha1-6xDMb4K4xJDj6FaY8H6D1G4MuoI=",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bitsyntax/-/bitsyntax-0.1.0.tgz",
+      "integrity": "sha512-ikAdCnrloKmFOugAfxWws89/fPc+nw0OOG1IzIE72uSOg/A3cYptKCjSUhDTuj7fhsJtzkzlv7l3b8PzRHLN0Q==",
       "requires": {
-        "buffer-more-ints": "0.0.2"
+        "buffer-more-ints": "~1.0.0",
+        "debug": "~2.6.9",
+        "safe-buffer": "~5.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "bluebird": {
@@ -75,9 +87,9 @@
       "dev": true
     },
     "buffer-more-ints": {
-      "version": "0.0.2",
-      "resolved": "http://npm.tescloud.com/buffer-more-ints/-/buffer-more-ints-0.0.2.tgz",
-      "integrity": "sha1-JrOIXRD6E9t/wBquOquHAZngEkw="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz",
+      "integrity": "sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg=="
     },
     "camelcase": {
       "version": "1.2.1",
@@ -146,12 +158,18 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "debug": {
-      "version": "2.6.8",
-      "resolved": "http://npm.tescloud.com/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-      "dev": true,
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "decamelize": {
@@ -483,6 +501,15 @@
         "supports-color": "3.1.2"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "glob": {
           "version": "7.1.1",
           "resolved": "http://npm.tescloud.com/glob/-/glob-7.1.1.tgz",
@@ -520,8 +547,7 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "http://npm.tescloud.com/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "nopt": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "bitsyntax": "~0.1.0",
     "bluebird": "^3.5.2",
     "buffer-more-ints": "~1.0.0",
+    "debug": "^4.1.1",
     "readable-stream": "1.x >=1.1.9",
     "safe-buffer": "~5.1.2",
     "url-parse": "~1.4.3"

--- a/test/connection.js
+++ b/test/connection.js
@@ -413,7 +413,7 @@ test("send heartbeats at interval / 2", function(done) {
             var expectedTime = heartbeat.UNITS_TO_MS / 2;
             var buffer = expectedTime * 0.20; // percent
             var amountOff = Math.abs(expectedTime - deltaTime);
-            assert(amountOff <= buffer, `Expected delta time of ${expectedTime} (with a buffer of +- ${buffer}), got ${deltaTime}`);
+            assert(amountOff <= buffer, "Expected delta time of " + expectedTime + " (with a buffer of +- " + buffer + "), got " + deltaTime);
           }
 
           lastBeatTime = beatTime;

--- a/test/connection.js
+++ b/test/connection.js
@@ -410,7 +410,7 @@ test("send heartbeats at interval / 2", function(done) {
           var beatTime = Date.now();
           if (lastBeatTime !== 0) {
             var deltaTime = beatTime - lastBeatTime;
-            var expectedTime = heartbeat.UNITS_TO_MS / 2;
+            var expectedTime = interval * heartbeat.UNITS_TO_MS / 2;
             var buffer = expectedTime * 0.20; // percent
             var amountOff = Math.abs(expectedTime - deltaTime);
             assert(amountOff <= buffer, "Expected delta time of " + expectedTime + " (with a buffer of +- " + buffer + "), got " + deltaTime);


### PR DESCRIPTION
Hello!

I'm using this library in a production setting; and I noticed that under load I would occasionally timeout due to missing heartbeats. Looking at the logic of determining whether or not to send a heartbeat, I realized the library actually doesn't send heartbeats at t/2 intervals (as intended by the comments in `lib/heartbeat.js`) but t intervals. Under load, we could miss timeouts.

This PR changes the way the library determines whether or not we should send a heartbeat by using time with a buffer rather than a boolean flag. You'll see a test I added in https://github.com/squaremo/amqp.node/commit/fd47fbdb8485843307feb7a82c6b2d6c61c61035 that demonstrates the bug (by failing). 

Here's a potential scenario of current behavior that is failing in my production environment:
1. `sendHearbeat` is called
1. `sendBytes` is called inside `sendHeartbeat`
1. `setSinceLastCheck` set to `true` inside of `sendBytes`
1. No network traffic occurs
1. `intervalMs / 2` time elapses and `Heart.runHeartbeat` is called
1. `runHeartbeat` runs `check` which is `Connection.checkSend` in this case
1. `checkSend` returns the old value of `setSinceLastCheck` (which is `true`) and sets `setSinceLastCheck` to `false`
1. `runHeartbeat` doesn't `fail()` due to `!true` condition and therefore doesn't send a heartbeat when we'd expect it to send a heartbeat every `intervalMs / 2` given no other traffic
1. No network traffic occurs
1. `intervalMs / 2` time elapses. We're now very close to `intervalMs` which is the timeout period. Under load, the `setInterval` may be a little late and miss the timeout period
1. We get a heartbeat timeout from the server because we sent a beat a tad late

I've tested these changes in my production environment, and seem to work great

Let me know if you have any questions!
