### PR TITLE
package: add a postinstall script when lib is distributed via git

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   },
   "scripts": {
     "test": "make test",
-    "prepare": "make"
+    "prepare": "make",
+    "postinstall": "make lib/defs.js"
   },
   "keywords": [
     "AMQP",


### PR DESCRIPTION
Right now, the `lib/defs.js` generated file is only available on packages published on NPM because it is generated during the `prepare` phase of the NPM packaging step.

By adding a postinstall step we make sure the file is also generated by other publishing means (be it local package path or git path for instance).

This additional `postinstall` hook could seem “dangerous” at first glance however:

- if the `lib/defs.js` file is already present, then `make` won't do anything.
- if `npm install` is ran in “production” mode (be it with `--production` or `NODE_ENV=production`) in a project including this lib (`amqplib`), the `devDependencies` of the lib will get installed and the `postinstall` hook will work as expected. (At least that's what happened on Debian OS)

If you have a better idea on how the `lib/defs.js` can be generated in case the lib is used via git / http (instead of npm registry) please let me know, I'd be very much interested.

Thanks!