### PR TITLE
Download amqp.json from "rabbitmq-server" repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
-RABBITMQ_SRC_VERSION=rabbitmq_v3_2_1
+COMMIT_OR_BRANCH=a334b711ad37493cdccdd141079c4af974a9b054
 JSON=amqp-rabbitmq-0.9.1.json
-RABBITMQ_CODEGEN=https://raw.githubusercontent.com/rabbitmq/rabbitmq-codegen
-AMQP_JSON=$(RABBITMQ_CODEGEN)/$(RABBITMQ_SRC_VERSION)/$(JSON)
+AMQP_JSON_LOCATION=https://raw.githubusercontent.com/rabbitmq/rabbitmq-server/$(COMMIT_OR_BRANCH)/deps/rabbitmq_codegen/$(JSON)
 
 NODEJS_VERSIONS='0.8' '0.9' '0.10' '0.11' '0.12' '1.8.4' '2.5' '3.3' '4.9' '5.12' '6.17' '8.17' '9.11' '10.21' '11.15' '12.18' '13.14' '14.5' '15.8'
 
@@ -15,10 +14,10 @@ ISTANBUL=./node_modules/.bin/istanbul
 all: lib/defs.js
 
 clean:
-	rm lib/defs.js bin/amqp-rabbitmq-0.9.1.json
+	rm lib/defs.js bin/$(JSON)
 	rm -rf ./coverage
 
-lib/defs.js: $(UGLIFY) bin/generate-defs.js bin/amqp-rabbitmq-0.9.1.json
+lib/defs.js: $(UGLIFY) bin/generate-defs.js bin/$(JSON)
 	(cd bin; node ./generate-defs.js > ../lib/defs.js)
 	$(UGLIFY) ./lib/defs.js -o ./lib/defs.js \
 		-c 'sequences=false' --comments \
@@ -39,7 +38,7 @@ coverage: $(ISTANBUL) lib/defs.js
 	@echo "HTML report at file://$$(pwd)/coverage/lcov-report/index.html"
 
 bin/amqp-rabbitmq-0.9.1.json:
-	curl -L $(AMQP_JSON) > $@
+	curl -L $(AMQP_JSON_LOCATION) > $@
 
 $(ISTANBUL):
 	npm install


### PR DESCRIPTION
The original repository, [rabbitmq-codegen](https://github.com/rabbitmq/rabbitmq-codegen) has been moved to the main unified RabbitMQ mono repository, [rabbitmq-server](https://github.com/rabbitmq/rabbitmq-server). This PR updates the source URL.