### PR TITLE
added support for 'U' and 'u' to codec

### DIFF
--- a/lib/codec.js
+++ b/lib/codec.js
@@ -279,6 +279,10 @@ function decodeFields(slice) {
         case 'l':
             val = ints.readInt64BE(slice, offset); offset += 8;
             break;
+        case 'u':
+            val = slice.readUInt16BE(offset); offset += 2;
+            break;
+        case 'U':
         case 's':
             val = slice.readInt16BE(offset); offset += 2;
             break;


### PR DESCRIPTION
I had trouble decoding a number (unsigned 16 bit integer) created by a python client (https://github.com/pika/pika) and consumed by this client. I found out that there is no implementation for 'u'.

Let me know if i am missing something, i am not so familiar with nodejs and doing pullrequests ;).

