### PR TITLE
Close connection to server on connect errors

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -152,8 +152,12 @@ function connect(url, socketOptions, openCallback) {
       if (timeout) sock.setTimeout(0);
       if (err === null) {
         openCallback(null, c);
+      } else {
+        // The connection isn't closed by the server on e.g. wrong password
+        sock.end();
+        sock.destroy();
+        openCallback(err);
       }
-      else openCallback(err);
     });
   }
 


### PR DESCRIPTION
A minimal pull request to fix open socket leak after e.g. authentication error on connect. This is a part of the fix in #584, but I have only kept the most essential part and added a test.

By keeping this as small as possible, I hope to remove any hesitance so that it can be merged.