### PR TITLE
use .push.apply instead of concat in Mux _readIncoming

### DIFF
--- a/lib/mux.js
+++ b/lib/mux.js
@@ -77,7 +77,7 @@ Mux.prototype._readIncoming = function() {
   }
   else { // ran out of room
     assert(this.newStreams.length > 0, "Expect some new streams to remain");
-    this.oldStreams.push.apply(this.newStreams);
+    Array.prototype.push.apply(this.oldStreams, this.newStreams);
     this.newStreams = [];
   }
   // We may have exhausted all the old queues, or run out of room;

--- a/lib/mux.js
+++ b/lib/mux.js
@@ -8,7 +8,6 @@
 // it then writes 'packets' from the upstreams to the given
 // downstream.
 
-var inherits = require('util').inherits;
 var assert = require('assert');
 
 var schedule = (typeof setImmediate === 'function') ?
@@ -47,7 +46,6 @@ Mux.prototype._readIncoming = function() {
   // become readable
   if (this.blocked) return;
 
-  var self = this;
   var accepting = true;
   var out = this.out;
 
@@ -79,7 +77,7 @@ Mux.prototype._readIncoming = function() {
   }
   else { // ran out of room
     assert(this.newStreams.length > 0, "Expect some new streams to remain");
-    this.oldStreams = this.oldStreams.concat(this.newStreams);
+    this.oldStreams.push.apply(this.newStreams);
     this.newStreams = [];
   }
   // We may have exhausted all the old queues, or run out of room;


### PR DESCRIPTION
Also
remove unused require
remove unused self variable

#657

Should reduce memory footprint and performance