### PR TITLE
call unregisterConsumer in handleCancel

### DIFF
--- a/lib/channel.js
+++ b/lib/channel.js
@@ -493,5 +493,7 @@ BaseChannel.prototype.handleDelivery = function(message) {
 };
 
 BaseChannel.prototype.handleCancel = function(fields) {
-  return this.dispatchMessage(fields, null);
+  var result = this.dispatchMessage(fields, null);
+  this.unregisterConsumer(fields.consumerTag);
+  return result;
 };


### PR DESCRIPTION
This PR adds a call to unregisterConsumer in handleCancel. This ensures, that the consumer gets removed from this.consumers.

Fixes #585