### PR TITLE
Use Map instead of Object for BaseChannel.consumers

### DIFF
--- a/lib/channel.js
+++ b/lib/channel.js
@@ -460,7 +460,7 @@ C.onBufferDrain = function() {
 // low-level machinery.
 function BaseChannel(connection) {
   Channel.call(this, connection);
-  this.consumers = {};
+  this.consumers = new Map();
 }
 inherits(BaseChannel, Channel);
 
@@ -469,16 +469,16 @@ module.exports.BaseChannel = BaseChannel;
 // Not sure I like the ff, it's going to be changing hidden classes
 // all over the place. On the other hand, whaddya do.
 BaseChannel.prototype.registerConsumer = function(tag, callback) {
-  this.consumers[tag] = callback;
+  this.consumers.set(tag, callback);
 };
 
 BaseChannel.prototype.unregisterConsumer = function(tag) {
-  delete this.consumers[tag];
+  this.consumers.delete(tag);
 };
 
 BaseChannel.prototype.dispatchMessage = function(fields, message) {
   var consumerTag = fields.consumerTag;
-  var consumer = this.consumers[consumerTag];
+  var consumer = this.consumers.get(consumerTag);
   if (consumer) {
     return consumer(message);
   }


### PR DESCRIPTION
This PR uses a Map instead of an Object for BaseChannel.consumers. It should improve the performance while running in node, as the amount of V8-HiddenClasses will be reduced. 

Use Case: If in your implementation alot of consumers get created and canceled, alot of unique V8-HiddenClasses will be created in V8 at runtime. 

Information regarding HiddenClasses:
https://v8.dev/blog/slack-tracking

