### PR TITLE
transform throws string into throw Error

### DIFF
--- a/lib/channel.js
+++ b/lib/channel.js
@@ -268,8 +268,8 @@ function acceptDeliveryOrReturn(f) {
   var event;
   if (f.id === defs.BasicDeliver) event = 'delivery';
   else if (f.id === defs.BasicReturn) event = 'return';
-  else throw fmt("Expected BasicDeliver or BasicReturn; got %s",
-                 inspect(f));
+  else throw new Error(fmt("Expected BasicDeliver or BasicReturn; got %s",
+                 inspect(f)));
 
   var self = this;
   var fields = f.fields;
@@ -310,7 +310,7 @@ function acceptMessage(continuation) {
       }
     }
     else {
-      throw "Expected headers frame after delivery";
+      throw new Error("Expected headers frame after delivery");
     }
   }
 
@@ -332,8 +332,8 @@ function acceptMessage(continuation) {
         return acceptDeliveryOrReturn;
       }
       else if (remaining < 0) {
-        throw fmt("Too much content sent! Expected %d bytes",
-                  totalSize);
+        throw new Error(fmt("Too much content sent! Expected %d bytes",
+                  totalSize));
       }
       else {
         if (buffers !== null)
@@ -343,7 +343,7 @@ function acceptMessage(continuation) {
         return content;
       }
     }
-    else throw "Expected content frame after headers"
+    else throw new Error("Expected content frame after headers");
   }
 }
 


### PR DESCRIPTION
@squaremo 
While analyzing amqplib in sonarqube I found that some throws do tot throw an Error-Object but merely a string. 

If you now run the tests, two of them fail. 

```
1) Consume from non-queue invokes error k
2) bad delivery
```

Responsible for failing these tests is the change in line 346. 

I suspect, that this is a valid code smell but I quite dont understand how I could fix this. 