### PR TITLE
Site hostname change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # AMQP 0-9-1 library and client for Node.JS
 
-[![Build Status](https://travis-ci.org/squaremo/amqp.node.png)](https://travis-ci.org/squaremo/amqp.node)
-
     npm install amqplib
 
  * [Change log][changelog]

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 A library for making AMQP 0-9-1 clients for Node.JS, and an AMQP 0-9-1 client for Node.JS v10+.
 
 This library does not implement [AMQP
-1.0](https://github.com/squaremo/amqp.node/issues/63) or [AMQP
-0-10](https://github.com/squaremo/amqp.node/issues/94).
+1.0](https://github.com/amqp-node/amqplib/issues/63) or [AMQP
+0-10](https://github.com/amqp-node/amqplib/issues/94).
 
 Project status:
 
@@ -144,10 +144,10 @@ really only useful for checking the kind and formatting of the errors.
     make coverage
     open file://`pwd`/coverage/lcov-report/index.html
 
-[gh-pages]: http://www.squaremobius.net/amqp.node/
-[gh-pages-apiref]: http://www.squaremobius.net/amqp.node/channel_api.html
+[gh-pages]: http://amqp-node.github.io/amqplib/
+[gh-pages-apiref]: http://amqp-node.github.io/amqplib/channel_api.html
 [nave]: https://github.com/isaacs/nave
-[tutes]: https://github.com/squaremo/amqp.node/tree/main/examples/tutorials
+[tutes]: https://github.com/amqp-node/amqplib/tree/main/examples/tutorials
 [rabbitmq-tutes]: http://www.rabbitmq.com/getstarted.html
-[changelog]: https://github.com/squaremo/amqp.node/blob/main/CHANGELOG.md
+[changelog]: https://github.com/amqp-node/amqplib/blob/main/CHANGELOG.md
 [docker]: https://www.docker.com/

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 
 {
   "name": "amqplib",
-  "homepage": "http://squaremo.github.io/amqp.node/",
+  "homepage": "http://amqp-node.github.io/amqplib/",
   "main": "./channel_api.js",
   "version": "0.8.0",
   "description": "An AMQP 0-9-1 (e.g., RabbitMQ) library and client.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/squaremo/amqp.node.git"
+    "url": "https://github.com/amqp-node/amqplib.git"
   },
   "engines": {
     "node": ">=10"


### PR DESCRIPTION
Updates links that were hard-wired to www.squaremobius.net to use amqp-node.github.io.

The old hostname came about because I used a CNAME (file) for my GitHub pages website, and it would redirect from squaremo.github.io/amqp.node to the CNAME. Now the repo is here, this is not desired. I've set up something to redirect, but we may as well make links here correct, too.

I removed the CI badge because 1. Travis-CI.org is defunct, and 2. testing is done with GitHub Actions now anyway.