### PR TITLE
fix: done called twice on invalid options

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -178,8 +178,7 @@ C.open = function(allFields, openCallback0) {
   function send(Method) {
     // This can throw an exception if there's some problem with the
     // options; e.g., something is a string instead of a number.
-    try { self.sendMethod(0, Method, tunedOptions); }
-    catch (err) { bail(err); }
+    self.sendMethod(0, Method, tunedOptions);
   }
 
   function negotiate(server, desired) {
@@ -205,7 +204,12 @@ C.open = function(allFields, openCallback0) {
       return;
     }
     self.serverProperties = start.fields.serverProperties;
-    send(defs.ConnectionStartOk);
+    try {
+      send(defs.ConnectionStartOk);
+    } catch (err) {
+      bail(err);
+      return;
+    }
     wait(afterStartOk);
   }
 
@@ -227,8 +231,13 @@ C.open = function(allFields, openCallback0) {
         negotiate(fields.channelMax, allFields.channelMax);
       tunedOptions.heartbeat =
         negotiate(fields.heartbeat, allFields.heartbeat);
-      send(defs.ConnectionTuneOk);
-      send(defs.ConnectionOpen);
+      try {
+        send(defs.ConnectionTuneOk);
+        send(defs.ConnectionOpen);
+      } catch (err) {
+        bail(err);
+        return;
+      }
       expect(defs.ConnectionOpenOk, onOpenOk);
       break;
     default:


### PR DESCRIPTION
Fixes CI with node version 10.

The problem was that the steps in `afterStartOk` weren't aborted even though an error was detected and `bail` was called. Thus the callback was called at least twice.