### PR TITLE
Use Buffer.allocUnsafe to reduce allocations and CPU usage

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -560,7 +560,7 @@ C.sendMessage = function(channel,
   var allLen = methodHeaderLen + bodyLen;
 
   if (allLen < SINGLE_CHUNK_THRESHOLD) {
-    var all = Buffer.alloc(allLen);
+    var all = Buffer.allocUnsafe(allLen);
     var offset = mframe.copy(all, 0);
     offset += pframe.copy(all, offset);
 
@@ -570,7 +570,7 @@ C.sendMessage = function(channel,
   }
   else {
     if (methodHeaderLen < SINGLE_CHUNK_THRESHOLD) {
-      var both = Buffer.alloc(methodHeaderLen);
+      var both = Buffer.allocUnsafe(methodHeaderLen);
       var offset = mframe.copy(both, 0);
       pframe.copy(both, offset);
       buffer.write(both);

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -560,6 +560,9 @@ C.sendMessage = function(channel,
   var allLen = methodHeaderLen + bodyLen;
 
   if (allLen < SINGLE_CHUNK_THRESHOLD) {
+    // Use `allocUnsafe` to avoid excessive allocations and CPU usage
+    // from zeroing. The returned Buffer is not zeroed and so must be
+    // completely filled to be used safely.
     var all = Buffer.allocUnsafe(allLen);
     var offset = mframe.copy(all, 0);
     offset += pframe.copy(all, offset);
@@ -570,6 +573,9 @@ C.sendMessage = function(channel,
   }
   else {
     if (methodHeaderLen < SINGLE_CHUNK_THRESHOLD) {
+      // Use `allocUnsafe` to avoid excessive allocations and CPU usage
+      // from zeroing. The returned Buffer is not zeroed and so must be
+      // completely filled to be used safely.
       var both = Buffer.allocUnsafe(methodHeaderLen);
       var offset = mframe.copy(both, 0);
       pframe.copy(both, offset);


### PR DESCRIPTION
`Buffer.allocUnsafe` will prefer to create non-zeroed buffers using the buffer pool rather than creating a new zeroed buffer each time like `Buffer.alloc`. Despite the name, `Buffer.allocUnsafe` is safe to use if you are immediately overwriting all the content in the buffer, and it is preferred for library APIs that will be called a lot or will be doing a lot of allocations.

https://nodejs.org/api/buffer.html#static-method-bufferallocunsafesize