### PR TITLE
chore: slice -> subarray

### DIFF
--- a/bin/generate-defs.js
+++ b/bin/generate-defs.js
@@ -495,7 +495,7 @@ function decoderFn(method) {
       break;
     case 'longstr':
       println('len = buffer.readUInt32BE(offset); offset += 4;');
-      println('val = buffer.slice(offset, offset + len);');
+      println('val = buffer.subarray(offset, offset + len);');
       println('offset += len;');
       break;
     case 'shortstr':
@@ -505,7 +505,7 @@ function decoderFn(method) {
       break;
     case 'table':
       println('len = buffer.readUInt32BE(offset); offset += 4;');
-      println('val = decodeFields(buffer.slice(offset, offset + len));');
+      println('val = decodeFields(buffer.subarray(offset, offset + len));');
       println('offset += len;');
       break;
     default:
@@ -657,7 +657,7 @@ function encodePropsFn(props) {
   // size does not include the frame header or frame end byte
   println('buffer.writeUInt32BE(offset - 7, 3);');
   println('buffer.writeUInt16BE(flags, 19);');
-  println('return buffer.slice(0, offset + 1);');
+  println('return buffer.subarray(0, offset + 1);');
   println('}');
 }
 
@@ -697,7 +697,7 @@ function decodePropsFn(props) {
         break;
       case 'longstr':
         println('len = buffer.readUInt32BE(offset); offset += 4;');
-        println('val = buffer.slice(offset, offset + len);');
+        println('val = buffer.subarray(offset, offset + len);');
         println('offset += len;');
         break;
       case 'shortstr':
@@ -707,7 +707,7 @@ function decodePropsFn(props) {
         break;
       case 'table':
         println('len = buffer.readUInt32BE(offset); offset += 4;');
-        println('val = decodeFields(buffer.slice(offset, offset + len));');
+        println('val = decodeFields(buffer.subarray(offset, offset + len));');
         println('offset += len;');
         break;
       default:

--- a/lib/codec.js
+++ b/lib/codec.js
@@ -262,7 +262,7 @@ function decodeFields(slice) {
             break;
         case 'F':
             len = slice.readUInt32BE(offset); offset += 4;
-            val = decodeFields(slice.slice(offset, offset + len));
+            val = decodeFields(slice.subarray(offset, offset + len));
             offset += len;
             break;
         case 'A':
@@ -290,7 +290,7 @@ function decodeFields(slice) {
             break;
         case 'x':
             len = slice.readUInt32BE(offset); offset += 4;
-            val = slice.slice(offset, offset + len);
+            val = slice.subarray(offset, offset + len);
             offset += len;
             break;
         default:

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -538,7 +538,7 @@ class Connection extends EventEmitter {
 
     for (var offset = 0; offset < body.length; offset += maxBody) {
       var end = offset + maxBody;
-      var slice = (end > body.length) ? body.slice(offset) : body.slice(offset, end);
+      var slice = (end > body.length) ? body.subarray(offset) : body.subarray(offset, end);
       var bodyFrame = makeBodyFrame(channel, slice);
       writeResult = buffer.write(bodyFrame);
     }

--- a/lib/credentials.js
+++ b/lib/credentials.js
@@ -27,7 +27,7 @@ module.exports.amqplain = function(user, passwd) {
     response: function() {
       const buffer = Buffer.alloc(16384);
       const size = codec.encodeTable(buffer, { LOGIN: user, PASSWORD: passwd}, 0);
-      return buffer.slice(4, size);
+      return buffer.subarray(4, size);
     },
     username: user,
     password: passwd

--- a/test/codec.js
+++ b/test/codec.js
@@ -70,7 +70,7 @@ suite("Implicit encodings", function() {
     test(name, function() {
       var buffer = Buffer.alloc(1000);
       var size = codec.encodeTable(buffer, val, 0);
-      var result = buffer.slice(4, size);
+      var result = buffer.subarray(4, size);
       assert.deepEqual(expect, bufferToArray(result));
     });
   });
@@ -83,7 +83,7 @@ var amqp = require('./data');
 function roundtrip_table(t) {
   var buf = Buffer.alloc(4096);
   var size = codec.encodeTable(buf, t, 0);
-  var decoded = codec.decodeFields(buf.slice(4, size)); // ignore the length-prefix
+  var decoded = codec.decodeFields(buf.subarray(4, size)); // ignore the length-prefix
   try {
     assert.deepEqual(removeExplicitTypes(t), decoded);
   }
@@ -204,7 +204,7 @@ function roundtripMethod(Method) {
   return forAll(Method).satisfy(function(method) {
     var buf = defs.encodeMethod(method.id, 0, method.fields);
     // FIXME depends on framing, ugh
-    var fs1 = defs.decode(method.id, buf.slice(11, buf.length));
+    var fs1 = defs.decode(method.id, buf.subarray(11, buf.length));
     assertEqualModuloDefaults(method, fs1);
     return true;
   });
@@ -215,7 +215,7 @@ function roundtripProperties(Properties) {
     var buf = defs.encodeProperties(properties.id, 0, properties.size,
                                     properties.fields);
     // FIXME depends on framing, ugh
-    var fs1 = defs.decode(properties.id, buf.slice(19, buf.length));
+    var fs1 = defs.decode(properties.id, buf.subarray(19, buf.length));
     assert.equal(properties.size, ints.readUInt64BE(buf, 11));
     assertEqualModuloDefaults(properties, fs1);
     return true;

--- a/test/frame.js
+++ b/test/frame.js
@@ -38,9 +38,9 @@ suite("Explicit parsing", function() {
   test('Parse partitioned', function() {
     var input = inputs();
     var frames = new Frames(input);
-    input.write(HB.slice(0, 3));
+    input.write(HB.subarray(0, 3));
     assert(!frames.recvFrame());
-    input.write(HB.slice(3));
+    input.write(HB.subarray(3));
     assert(frames.recvFrame() === HEARTBEAT);
     assert(!frames.recvFrame());
   });
@@ -143,9 +143,9 @@ suite("Parsing", function() {
          var onethird = Math.floor(full.length / 3);
          var twothirds = 2 * onethird;
          return [
-           full.slice(0, onethird),
-           full.slice(onethird, twothirds),
-           full.slice(twothirds)
+           full.subarray(0, onethird),
+           full.subarray(onethird, twothirds),
+           full.subarray(twothirds)
          ];
        }));
 });


### PR DESCRIPTION
it was bad of NodeJS to override slice with an alias of subarray that dose two different things... if ppl actually wish to make a new sub-view of same underlying buffer then they should have actually used subarray instead which cased confusion from developer thinking that `slice()` would cause a immutable copy.

so they have now [deprecated buffer.slice](https://nodejs.org/dist/latest-v20.x/docs/api/buffer.html#bufslicestart-end)