### PR TITLE
Add support for x-queue-type option

### DIFF
--- a/lib/api_args.js
+++ b/lib/api_args.js
@@ -60,6 +60,7 @@ Args.assertQueue = function(queue, options) {
   setIfDefined(argt, 'x-max-priority', options.maxPriority);
   setIfDefined(argt, 'x-overflow', options.overflow);
   setIfDefined(argt, 'x-queue-mode', options.queueMode);
+  setIfDefined(argt, 'x-queue-type', options.queueType);
 
   return {
     queue: queue,


### PR DESCRIPTION
This commit adds support for the `queueType` option in the `Channel#assertQueue` function. The `queueType` option allows users to specify the type of the queue. Just likes the other options of RabbitMQ extensions can also be supplied as options.