### PR TITLE
Github Pages Fixes

### DIFF
--- a/channel_api.md
+++ b/channel_api.md
@@ -362,17 +362,14 @@ URI, e.g., as in `'amqp://localhost?frameMax=0x1000'`. These are:
    connection. `0` means no limit (but since frames have a size field
    which is an unsigned 32 bit integer, it's perforce `2^32 - 1`); I
    default it to 0x1000, i.e. 4kb, which is the allowed minimum, will
-   fit many purposes, and not chug through Node.JS's buffer pooling.
-
+   fit many purposes, and not chug through Node.JS's buffer pooling.<br/><br/>
  * `channelMax`, the maximum number of channels allowed. Default is
-   `0`, meaning `2^16 - 1`.
-
+   `0`, meaning `2^16 - 1`.<br/><br/>
  * `heartbeat`: the period of the connection heartbeat, in
-   seconds. Defaults to `0`; see [heartbeating](#heartbeating)
-
+   seconds. Defaults to `0`; see [heartbeating](#heartbeating)<br/><br/>
  * `locale`: the desired locale for error messages, I
    suppose. RabbitMQ only ever uses `en_US`; which, happily, is the
-   default.
+   default.<br/><br/>
 
 ###### Connecting with an object instead of a URL
 
@@ -695,17 +692,14 @@ random name for you.
 if it's the last argument. The relevant fields in options are:
 
  * `exclusive`: if true, scopes the queue to the connection (defaults
-  to false)
-
+  to false)<br/><br/>
  * `durable`: if true, the queue will survive broker restarts, modulo
   the effects of `exclusive` and `autoDelete`; this defaults to true
-  if not supplied, unlike the others
-
+  if not supplied, unlike the others<br/><br/>
  * `autoDelete`: if true, the queue will be deleted when the number of
-  consumers drops to zero (defaults to false)
-
+  consumers drops to zero (defaults to false)<br/><br/>
  * `arguments`: additional arguments, usually parameters for some kind
-  of broker-specific extension e.g., high availability, TTL.
+  of broker-specific extension e.g., high availability, TTL.<br/><br/>
 
 RabbitMQ extensions can also be supplied as options. These typically
 require non-standard `x-*` keys and values, sent in the `arguments`
@@ -715,26 +709,22 @@ prefix for the key is removed; e.g., `'expires'`. Values supplied in
 `options.arguments`.
 
  * `messageTtl` (0 <= n < 2^32): expires messages arriving in the
-  queue after n milliseconds
-
+  queue after n milliseconds<br/><br/>
  * `expires` (0 < n < 2^32): the queue will be destroyed after n
   milliseconds of disuse, where use means having consumers, being
   declared (asserted or checked, in this API), or being polled with a
-  `#get`.
-
+  `#get`.<br/><br/>
  * `deadLetterExchange` (string): an exchange to which messages
   discarded from the queue will be resent. Use `deadLetterRoutingKey`
   to set a routing key for discarded messages; otherwise, the
   message's routing key (and CC and BCC, if present) will be
   preserved. A message is discarded when it expires or is rejected or
-  nacked, or the queue limit is reached.
-
+  nacked, or the queue limit is reached.<br/><br/>
  * `maxLength` (positive integer): sets a maximum number of messages
   the queue will hold. Old messages will be discarded (dead-lettered
-  if that's set) to make way for new messages.
-
+  if that's set) to make way for new messages.<br/><br/>
  * `maxPriority` (positive integer): makes the queue a [priority
-   queue][rabbitmq-priority-queue].
+   queue][rabbitmq-priority-queue].<br/><br/>
 
 Resolves to the "ok" reply from the server, which includes fields for
 the queue name (important if you let the server name it), a recent
@@ -781,11 +771,10 @@ RabbitMQ version 3.2.0 and after[1][rabbitmq-idempotent-delete]). The
 options here are:
 
  * `ifUnused` (boolean): if true and the queue has consumers, it will
-   not be deleted and the channel will be closed. Defaults to false.
-
+   not be deleted and the channel will be closed. Defaults to false.<br/><br/>
  * `ifEmpty` (boolean): if true and the queue contains messages, the
    queue will not be deleted and the channel will be closed. Defaults
-   to false.
+   to false.<br/><br/>
 
 Note the obverse semantics of the options: if both are true, the queue
 will be deleted only if it has no consumers *and* no messages.
@@ -886,21 +875,18 @@ use the `arguments` table to supply parameters.
 The options:
 
  * `durable` (boolean): if true, the exchange will survive broker
-  restarts. Defaults to true.
-
+  restarts. Defaults to true.<br/><br/>
  * `internal` (boolean): if true, messages cannot be published
   directly to the exchange (i.e., it can only be the target of
-  bindings, or possibly create messages ex-nihilo). Defaults to false.
+  bindings, or possibly create messages ex-nihilo). Defaults to false.<br/><br/>s
 
  * `autoDelete` (boolean): if true, the exchange will be destroyed
   once the number of bindings for which it is the source drop to
-  zero. Defaults to false.
-
+  zero. Defaults to false.<br/><br/>
  * `alternateExchange` (string): an exchange to send messages to if
-  this exchange can't route them to any queues.
-
+  this exchange can't route them to any queues.<br/><br/>
  * `arguments` (object): any additional arguments that may be needed
-   by an exchange type.
+   by an exchange type.<br/><br/>
 
 The server reply echoes the exchange name, in the field `exchange`.
 
@@ -932,7 +918,7 @@ be closed with an error. If it does exist, happy days.
 Delete an exchange. The only meaningful field in `options` is:
 
  * `ifUnused` (boolean): if true and the exchange has bindings, it
-  will not be deleted and the channel will be closed.
+  will not be deleted and the channel will be closed.<br/><br/>
 
 If the exchange does not exist, a channel error is raised (RabbitMQ
 version 3.2.0 and after will not raise an
@@ -996,63 +982,56 @@ Publish a single message to an exchange. The mandatory parameters are:
  (or undefined) as the exchange, which will send directly to the queue 
  named by the routing key; `#sendToQueue` below is equivalent to this special
  case. If the named exchange does not exist, the channel will be
- closed.
-
+ closed.<br/><br/>
  * `content`: a buffer containing the message content. This will be
  copied during encoding, so it is safe to mutate it once this method
- has returned.
+ has returned.<br/><br/>
 
 The remaining parameters are provided as fields in `options`, and are
 divided into those that have some meaning to RabbitMQ and those that
 will be ignored by RabbitMQ but passed on to consumers. `options` may
-be omitted altogether, in which case defaults as noted will apply.
+be omitted altogether, in which case defaults as noted will apply.<br/><br/>
 
 The "meaningful" options are a mix of fields in BasicDeliver (the
 method used to publish a message), BasicProperties (in the message
 header frame) and RabbitMQ extensions which are given in the `headers`
-table in BasicProperties.
+table in BasicProperties.<br/><br/>
 
 Used by RabbitMQ and sent on to consumers:
 
  * `expiration` (string): if supplied, the message will be discarded
    from a queue once it's been there longer than the given number of
    milliseconds. In the specification this is a string; numbers
-   supplied here will be coerced to strings for transit.
-
+   supplied here will be coerced to strings for transit.<br/><br/>
  * `userId` (string): If supplied, RabbitMQ will compare it to the
    username supplied when opening the connection, and reject messages
-   for which it does not match.
-
+   for which it does not match.<br/><br/>
  * `CC` (string or array of string): an array of routing keys as
    strings; messages will be routed to these routing keys in addition
    to that given as the `routingKey` parameter. A string will be
    implicitly treated as an array containing just that string. This
    will override any value given for `CC` in the `headers`
    parameter. **NB** The property names `CC` and `BCC` are
-   case-sensitive.
-
+   case-sensitive.<br/><br/>
  * `priority` (positive integer): a priority for the message; ignored
     by versions of RabbitMQ older than 3.5.0, or if the queue is not a
     [priority queue][rabbitmq-priority-queue] (see `maxPriority`
-    above).
-
+    above).<br/><br/>
  * `persistent` (boolean): If truthy, the message will survive broker
    restarts provided it's in a queue that also survives
    restarts. Corresponds to, and overrides, the property
-   `deliveryMode`.
-
+   `deliveryMode`.<br/><br/>
  * `deliveryMode` (boolean or numeric): Either `1` or falsey, meaning
    non-persistent; or, `2` or truthy, meaning persistent. That's just
-   obscure though. Use the option `persistent` instead.
+   obscure though. Use the option `persistent` instead.<br/><br/>
 
 Used by RabbitMQ but not sent on to consumers:
 
  * `mandatory` (boolean): if true, the message will be returned if it
    is not routed to a queue (i.e., if there are no bindings that match
-   its routing key).
-
+   its routing key).<br/><br/>
  * `BCC` (string or array of string): like `CC`, except that the value
-   will not be sent in the message headers to consumers.
+   will not be sent in the message headers to consumers.<br/><br/>
 
 Not used by RabbitMQ and not sent to consumers:
 
@@ -1060,37 +1039,29 @@ Not used by RabbitMQ and not sent to consumers:
    server to return the message if it is not able to be sent
    immediately to a consumer. No longer implemented in RabbitMQ, and
    if true, will provoke a channel error, so it's best to leave it
-   out.
+   out.<br/><br/>
 
 Ignored by RabbitMQ (but may be useful for applications):
 
- * `contentType` (string): a MIME type for the message content
-
- * `contentEncoding` (string): a MIME encoding for the message content
-
+ * `contentType` (string): a MIME type for the message content<br/><br/>
+ * `contentEncoding` (string): a MIME encoding for the message content<br/><br/>
  * `headers` (object): application specific headers to be carried
    along with the message content. The value as sent may be augmented
    by extension-specific fields if they are given in the parameters,
    for example, 'CC', since these are encoded as message headers; the
-   supplied value won't be mutated.
-
+   supplied value won't be mutated.<br/><br/>
  * `correlationId` (string): usually used to match replies to
-   requests, or similar
-
+   requests, or similar<br/><br/>
  * `replyTo` (string): often used to name a queue to which the
    receiving application must send replies, in an RPC scenario (many
-   libraries assume this pattern)
-
+   libraries assume this pattern)<br/><br/>
  * `messageId` (string): arbitrary application-specific identifier for
-   the message
-
- * `timestamp` (positive number): a timestamp for the message
-
+   the message<br/><br/>
+ * `timestamp` (positive number): a timestamp for the message<br/><br/>
  * `type` (string): an arbitrary application-specific type for the
-   message
-
+   message<br/><br/>
  * `appId` (string): an arbitrary identifier for the originating
-   application
+   application<br/><br/>
 
 `#publish` mimics the [`stream.Writable`][nodejs-write] interface in
 its return value; it will return `false` if the channel's write buffer
@@ -1130,30 +1101,25 @@ Options (which may be omitted if the last argument):
   distinguish message deliveries for the consumer; mustn't be already
   in use on the channel. It's usually easier to omit this, in which
   case the server will create a random name and supply it in the
-  reply.
-
+  reply.<br/><br/>
  * `noLocal` (boolean): in theory, if true then the broker won't
   deliver messages to the consumer if they were also published on this
   connection; RabbitMQ doesn't implement it though, and will ignore
-  it. Defaults to false.
-
+  it. Defaults to false.<br/><br/>
  * `noAck` (boolean): if true, the broker won't expect an
   acknowledgement of messages delivered to this consumer; i.e., it
   will dequeue messages as soon as they've been sent down the
   wire. Defaults to false (i.e., you will be expected to acknowledge
-  messages).
-
+  messages).<br/><br/>
  * `exclusive` (boolean): if true, the broker won't let anyone else
   consume from this queue; if there already is a consumer, there goes
   your channel (so usually only useful if you've made a 'private'
-  queue by letting the server choose its name).
-
+  queue by letting the server choose its name).<br/><br/>
  * `priority` (integer): gives a priority to the consumer; higher
    priority consumers get messages in preference to lower priority
    consumers. See [this RabbitMQ extension's
-   documentation][rabbitmq-consumer-priority]
-
- * `arguments` (object): arbitrary arguments. Go to town.
+   documentation][rabbitmq-consumer-priority]<br/><br/>
+ * `arguments` (object): arbitrary arguments. Go to town.<br/><br/>
 
 The server reply contains one field, `consumerTag`. It is necessary to
 remember this somewhere if you will later want to cancel this consume
@@ -1230,7 +1196,7 @@ Options:
  * `noAck` (boolean): if true, the message will be assumed by the server
    to be acknowledged (i.e., dequeued) as soon as it's been sent over
    the wire. Default is false, that is, you will be expected to
-   acknowledge the message.
+   acknowledge the message.<br/><br/>
 
 
 ### <a name="channel_ack"></a>Channel#ack

--- a/channel_api.md
+++ b/channel_api.md
@@ -1287,18 +1287,20 @@ works in older versions of RabbitMQ (< v2.3.0) where `#nack` does not.
 
 ### <a name="channel_prefetch"></a>Channel#prefetch
 
-##### Promises and callback APIs
+##### Promises API
 
 `#prefetch(count, [global])`
 
-**NOTE**: Does not return a promise in the promises API, or accept a callback in the callback API.
+##### Callback API
+
+`#prefetch(count, [[global], [function(err, ok) {...}]])`
 
 Set the prefetch count for this channel. The `count` given is the
 maximum number of messages sent over the channel that can be awaiting
 acknowledgement; once there are `count` messages outstanding, the
 server will not send more messages on this channel until one or more
 have been acknowledged. A falsey value for `count` indicates no such
-limit.
+limit. The server will reply (with an empty object) if successful.
 
 **NB** RabbitMQ v3.3.0 changes the meaning of prefetch (basic.qos) to
 apply per-*consumer*, rather than per-channel. It will apply to

--- a/channel_api.md
+++ b/channel_api.md
@@ -679,10 +679,9 @@ is ready for writes again).
 `#assertQueue([queue, [options, [function(err, ok) {...}]]])`
 
 Assert a queue into existence. This operation is idempotent given
-identical arguments; however, it will bork the channel if the queue
+identical arguments; however, it will break the channel if the queue
 already exists but has different properties (values supplied in the
-`arguments` field may or may not count for borking purposes; check the
-borker's, I mean broker's, documentation).
+`arguments` field may or may not matter; check the broker's, documentation).
 
 `queue` is a string; if you supply an empty string or other falsey
 value (including `null` and `undefined`), the server will create a
@@ -749,7 +748,7 @@ consumer count, and a recent message count; e.g.,
 
 `#checkQueue(queue, [function(err, ok) {...}])`
 
-Check whether a queue exists. This will bork the channel if the named
+Check whether a queue exists. This will break the channel if the named
 queue *doesn't* exist; if it does exist, you go through to the next
 round!  There's no options, unlike `#assertQueue()`, just the queue
 name. The reply from the server is the same as for `#assertQueue()`.
@@ -862,8 +861,8 @@ all[1][rabbitmq-idempotent-delete]. Good ol' RabbitMQ).
 
 Assert an exchange into existence. As with queues, if the exchange
 exists already and has properties different to those supplied, the
-channel will 'splode; fields in the arguments object may or may not be
-'splodey, depending on the type of exchange. Unlike queues, you must
+channel will break; fields in the arguments object may or may not matter,
+depending on the type of exchange. Unlike queues, you must
 supply a name, and it can't be the empty string. You must also supply
 an exchange type, which determines how messages will be routed through
 the exchange.
@@ -1221,7 +1220,7 @@ omitted, only the message supplied is acknowledged.
 
 It's an error to supply a message that either doesn't require
 acknowledgement, or has already been acknowledged. Doing so will
-errorise the channel. If you want to acknowledge all the messages and
+break the channel. If you want to acknowledge all the messages and
 you don't have a specific message around, use `#ackAll`.
 
 

--- a/channel_api.md
+++ b/channel_api.md
@@ -2,7 +2,7 @@
 layout: default
 title: Channel API reference
 ---
-<a name="top"></a>
+
 # Channel-oriented API reference
 
  * [Overview](#overview)
@@ -77,7 +77,6 @@ argument (and usually some value as the second argument). Likewise,
 "reject" etc., will mean rejecting a promise or calling the callback
 with an `Error` as the first argument (and no value).
 
-[^top](#top)
 
 ## <a name="overview"></a>Overview
 
@@ -102,7 +101,6 @@ server. These return either nothing (`ack[All]`, `nack[All]`, `reject`) or a
 boolean (`publish` and `sendToQueue`); see [flow
 control](#flowcontrol).
 
-[^top](#top)
 
 ## <a name="failure"></a>Dealing with failure
 
@@ -142,7 +140,6 @@ connection.createChannel().then(function(ch) {
 });
 ```
 
-[^top](#top)
 
 ### <a name="failure_promises"></a>Exceptions and promises
 
@@ -178,7 +175,6 @@ amqp.connect().then(function(conn) {
 });
 ```
 
-[^top](#top)
 
 ### <a name="failure_callbacks"></a>Exceptions and callbacks
 
@@ -214,7 +210,6 @@ dom.run(function() {
 });
 ```
 
-[^top](#top)
 
 ## <a name="flowcontrol"></a>Flow control
 
@@ -316,7 +311,6 @@ aliases for most encodings, as shown in the examples.
 
 NB AMQP only has signed integers in tables.
 
-[^top](#top)
 
 ## <a name="api_reference"></a>API reference
 
@@ -455,7 +449,6 @@ the server value is also `0`. See
 NOTE: Please consider NOT disabling heartbeats because they exist for a
 [reason](http://www.rabbitmq.com/heartbeats.html).
 
-[^top](#top)
 
 ## <a name="models"></a>ChannelModel and CallbackModel
 
@@ -464,7 +457,6 @@ take as an argument a `connection.Connection`. It is better to use
 `connect()`, which will open the connection for you. The constructors
 are exported as potential extension points.
 
-[^top](#top)
 
 ### <a name="model_close"></a>{Channel,Callback}Model#close
 
@@ -523,7 +515,6 @@ open.then(function(conn) {
 **NB** it's no good using `process.on('exit', ...)`, since `close()` needs
 to do I/O.
 
-[^top](#top)
 
 ### <a name="model_events"></a>{Channel,Callback}Model events
 
@@ -572,7 +563,6 @@ extension][rabbitmq-connection-blocked] for details.
 Emitted at some time after `'blocked'`, once the resource shortage has
 alleviated.
 
-[^top](#top)
 
 ### <a name="model_createChannel"></a>{Channel,Callback}Model#createChannel
 
@@ -589,7 +579,6 @@ channel; but it is not usable before the callback has been
 invoked). May fail if there are no more channels available (i.e., if
 there are already `channelMax` channels open).
 
-[^top](#top)
 
 ### <a name="model_createConfirmChannel"></a>{Channel,Callback}Model#createConfirmChannel
 
@@ -604,7 +593,6 @@ there are already `channelMax` channels open).
 Open a fresh channel, switched to "confirmation mode". See
 `ConfirmChannel` below.
 
-[^top](#top)
 
 ## <a name="channel"></a>Channels
 
@@ -623,7 +611,6 @@ point. When using a client API, obtain an open `Channel` by opening a
 connection (`connect()` above) and calling `#createChannel` or
 `#createConfirmChannel`.
 
-[^top](#top)
 
 ### <a name="channel_close"></a>Channel#close
 
@@ -645,7 +632,6 @@ channels, and thereby other things such as exclusive locks on queues,
 so it is occasionally worth being deliberate about opening and closing
 channels.
 
-[^top](#top)
 
 ### <a name="channel_events"></a>Channel events
 
@@ -684,7 +670,6 @@ if it has previously returned `false` from `#publish` or
 `#sendToQueue`, once its write buffer has been emptied (i.e., once it
 is ready for writes again).
 
-[^top](#top)
 
 ### <a name="channel_assertQueue"></a>Channel#assertQueue
 
@@ -763,7 +748,6 @@ consumer count, and a recent message count; e.g.,
 }
 ```
 
-[^top](#top)
 
 ### <a name="channel_checkQueue"></a>Channel#checkQueue
 
@@ -780,7 +764,6 @@ queue *doesn't* exist; if it does exist, you go through to the next
 round!  There's no options, unlike `#assertQueue()`, just the queue
 name. The reply from the server is the same as for `#assertQueue()`.
 
-[^top](#top)
 
 ### <a name="channel_deleteQueue"></a>Channel#deleteQueue
 
@@ -813,7 +796,6 @@ queue unconditionally.
 The server reply contains a single field, `messageCount`, with the
 number of messages deleted or dead-lettered along with the queue.
 
-[^top](#top)
 
 ### <a name="channel_purgeQueue"></a>Channel#purgeQueue
 
@@ -834,7 +816,6 @@ closes without acknowledging them).
 The server reply contains a single field, `messageCount`, containing
 the number of messages purged from the queue.
 
-[^top](#top)
 
 ### <a name="channel_bindQueue"></a>Channel#bindQueue
 
@@ -859,7 +840,6 @@ it's the last argument, which is equivalent to an empty object.
 
 The server reply has no fields.
 
-[^top](#top)
 
 ### <a name="channel_unbindQueue"></a>Channel#unbindQueue
 
@@ -880,7 +860,6 @@ mistake; RabbitMQ before version 3.2.0 softens this to a channel
 error, and from version 3.2.0, doesn't treat it as an error at
 all[1][rabbitmq-idempotent-delete]. Good ol' RabbitMQ).
 
-[^top](#top)
 
 ### <a name="channel_assertExchange"></a>Channel#assertExchange
 
@@ -925,7 +904,6 @@ The options:
 
 The server reply echoes the exchange name, in the field `exchange`.
 
-[^top](#top)
 
 ### <a name="channel_checkExchange"></a>Channel#checkExchange
 
@@ -940,7 +918,6 @@ The server reply echoes the exchange name, in the field `exchange`.
 Check that an exchange exists. If it doesn't exist, the channel will
 be closed with an error. If it does exist, happy days.
 
-[^top](#top)
 
 ### <a name="channel_deleteExchange"></a>Channel#deleteExchange
 
@@ -963,7 +940,6 @@ error[1][rabbitmq-idempotent-delete]).
 
 The server reply has no fields.
 
-[^top](#top)
 
 ### <a name="channel_bindExchange"></a>Channel#bindExchange
 
@@ -985,7 +961,6 @@ a routing key equal to the pattern.
 
 The server reply has no fields.
 
-[^top](#top)
 
 ### <a name="channel_unbindExchange"></a>Channel#unbindExchange
 
@@ -1004,7 +979,6 @@ exists, it's &ndash; you guessed it &ndash; a channel error, except in
 RabbitMQ >= version 3.2.0, for which it succeeds
 trivially[1][rabbitmq-idempotent-delete].
 
-[^top](#top)
 
 ### <a name="channel_publish"></a>Channel#publish
 
@@ -1123,7 +1097,6 @@ its return value; it will return `false` if the channel's write buffer
 is 'full', and `true` otherwise. If it returns `false`, it will emit a
 `'drain'` event at some later time.
 
-[^top](#top)
 
 ### <a name="channel_sendToQueue"></a>Channel#sendToQueue
 
@@ -1138,7 +1111,6 @@ Send a single message with the `content` given as a buffer to the
 specific `queue` named, bypassing routing. The options and return
 value are exactly the same as for `#publish`.
 
-[^top](#top)
 
 ### <a name="channel_consume"></a>Channel#consume
 
@@ -1217,7 +1189,6 @@ sent in the `headers` table so will appear there in deliveries.
 If the [consumer is cancelled][rabbitmq-consumer-cancel] by RabbitMQ,
 the message callback will be invoked with `null`.
 
-[^top](#top)
 
 ### <a name="channel_cancel"></a>Channel#cancel
 
@@ -1238,7 +1209,6 @@ will no longer be invoked.
 The `consumerTag` is the string given in the reply to `#consume`,
 which may have been generated by the server.
 
-[^top](#top)
 
 ### <a name="channel_get"></a>Channel#get
 
@@ -1262,7 +1232,6 @@ Options:
    the wire. Default is false, that is, you will be expected to
    acknowledge the message.
 
-[^top](#top)
 
 ### <a name="channel_ack"></a>Channel#ack
 
@@ -1289,7 +1258,6 @@ acknowledgement, or has already been acknowledged. Doing so will
 errorise the channel. If you want to acknowledge all the messages and
 you don't have a specific message around, use `#ackAll`.
 
-[^top](#top)
 
 ### <a name="channel_ackAll"></a>Channel#ackAll
 
@@ -1303,7 +1271,6 @@ Acknowledge all outstanding messages on the channel. This is a "safe"
 operation, in that it won't result in an error even if there are no
 such messages.
 
-[^top](#top)
 
 ### <a name="channel_nack"></a>Channel#nack
 
@@ -1328,7 +1295,6 @@ dead-lettered or discarded, supply `false` here.
 This and `#nackAll` use a [RabbitMQ-specific
 extension][rabbitmq-nack].
 
-[^top](#top)
 
 ### <a name="channel_nackAll"></a>Channel#nackAll
 
@@ -1341,7 +1307,6 @@ extension][rabbitmq-nack].
 Reject all messages outstanding on this channel. If `requeue` is
 truthy, or omitted, the server will try to re-enqueue the messages.
 
-[^top](#top)
 
 ### <a name="channel_reject"></a>Channel#reject
 
@@ -1354,7 +1319,6 @@ truthy, or omitted, the server will try to re-enqueue the messages.
 Reject a message. Equivalent to `#nack(message, false, requeue)`, but
 works in older versions of RabbitMQ (< v2.3.0) where `#nack` does not.
 
-[^top](#top)
 
 ### <a name="channel_prefetch"></a>Channel#prefetch
 
@@ -1380,7 +1344,6 @@ Use the `global` flag to get the per-channel behaviour. To keep life
 interesting, using the `global` flag with an RabbitMQ older than
 v3.3.0 will bring down the whole connection.
 
-[^top](#top)
 
 ### <a name="channel_recover"></a>Channel#recover
 
@@ -1395,7 +1358,6 @@ v3.3.0 will bring down the whole connection.
 Requeue unacknowledged messages on this channel. The server will reply
 (with an empty object) once all messages are requeued.
 
-[^top](#top)
 
 ## <a name="confirmchannel"></a>ConfirmChannel
 
@@ -1450,7 +1412,6 @@ This constructor is a channel that uses confirms. It is exported as an
 extension point. To obtain such a channel, use `connect` to get a
 connection, then call `#createConfirmChannel`.
 
-[^top](#top)
 
 ### <a name="confirmchannel_publish"></a>ConfirmChannel#publish
 
@@ -1463,7 +1424,6 @@ connection, then call `#createConfirmChannel`.
 
 `options` argument must be supplied, at least as an empty object.
 
-[^top](#top)
 
 ### <a name="confirmchannel_sendToQueue"></a>ConfirmChannel#sendToQueue
 
@@ -1476,7 +1436,6 @@ connection, then call `#createConfirmChannel`.
 
 `options` argument must be supplied, at least as an empty object.
 
-[^top](#top)
 
 ### <a name="confirmchannel_waitForConfirms"></a>ConfirmChannel#waitForConfirms
 
@@ -1495,7 +1454,6 @@ way, the channel is still usable afterwards. It is also possible to
 call waitForConfirms multiple times without waiting for previous
 invocations to complete.
 
-[^top](#top)
 
 ---------
 
@@ -1509,7 +1467,6 @@ This does not apply to preconditions given to the operations. For
 example deleting a queue with `{ifEmpty: true}` will still fail if
 there are messages in the queue.
 
-[^top](#top)
 
 [amqpurl]: http://www.rabbitmq.com/uri-spec.html
 [rabbitmq-tutes]: http://www.rabbitmq.com/getstarted.html


### PR DESCRIPTION
1. Removed broken top links - See https://github.com/amqp-node/amqplib/issues/741
2. Fixed bullet point formatting
3. Made the terminology more consistent - See https://github.com/amqp-node/amqplib/issues/742
4. Fixed the channel.prefetch API documentation
5. 