### PR TITLE
Make CI more robust

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     services:
       rabbitmq:
-        image: rabbitmq
+        image: rabbitmq:3.12-alpine
         ports:
           - 5672:5672
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x, 18.x]
+        node-version: [10.x, 12.x, 14.x, 16.x, 18.x, 20.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
@@ -33,6 +33,19 @@ jobs:
 
       # Install all prerequisites
       - run: npm ci
+
+      # Ensure RabbitMQ is available before continuing
+      - run: |
+          n=0
+          while :
+          do
+            sleep 5
+            echo 'HELO\n\n\n\n' | nc localhost 5672 | grep AMQP
+            [[ $? = 0 ]] && break || ((n++))
+            (( n >= 5 )) && break
+          done
+
+      - run: echo 'HELO\n\n\n\n' | nc localhost 5672 | grep AMQP
 
       # Run the tests
       - run: make test


### PR DESCRIPTION
The GitHub test action has been having intermittent test failures. I've modified it to use netcat to check that RabbitMQ is running, which seems to have made things more stable. I also added node 20 to the matrix.