### PR TITLE
Update channel_model.js

### DIFF
--- a/lib/channel_model.js
+++ b/lib/channel_model.js
@@ -204,6 +204,9 @@ class Channel extends BaseChannel {
   }
 
   ack(message, allUpTo) {
+    if (!message || !message.fields || typeof message.fields.deliveryTag === 'undefined') {
+      throw new Error('Invalid message parameter');
+    }
     this.sendImmediately(
       defs.BasicAck,
       Args.ack(message.fields.deliveryTag, allUpTo));


### PR DESCRIPTION
Got this error on the production server

(node:64) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'fields' of null at Channel.ack (/home/node/node_modules/amqplib/lib/callback_model.js:234:37) at _callee$ (/home/node/src/utils/services/rabbitmq-consumer-service.js:42:51)

My code is as follows
channel.ack(msg);

Fixed at my project but proposing the change at the library level by checking message object, thanks.

Using the same library version
  "name": "amqplib",
  "homepage": "http://amqp-node.github.io/amqplib/",
  "main": "./channel_api.js",
  "version": "0.10.3",