### PR TITLE
Support for unsigned int

### DIFF
--- a/lib/codec.js
+++ b/lib/codec.js
@@ -193,6 +193,10 @@ function encodeFieldValue(buffer, value, offset) {
         tag('s');
         buffer.writeInt16BE(val, offset); offset += 2;
         break;
+    case 'unsignedshort':
+    case 'uint16':
+        tag('u');
+        buffer.writeUInt16BE(val, offset); offset += 2;
     case 'int':
     case 'int32':
         tag('I');
@@ -281,6 +285,9 @@ function decodeFields(slice) {
             break;
         case 's':
             val = slice.readInt16BE(offset); offset += 2;
+            break;
+        case 'u':
+            val = slice.readUInt16BE(offset); offset += 2;
             break;
         case 't':
             val = slice[offset] != 0; offset++;

--- a/lib/codec.js
+++ b/lib/codec.js
@@ -188,6 +188,11 @@ function encodeFieldValue(buffer, value, offset) {
         tag('b');
         buffer.writeInt8(val, offset); offset++;
         break;
+    case 'unsigned byte':
+    case 'uint8':
+        tag('B');
+        buffer.writeUInt8(val, offset); offset++;
+        break;
     case 'short':
     case 'int16':
         tag('s');
@@ -201,6 +206,11 @@ function encodeFieldValue(buffer, value, offset) {
     case 'int32':
         tag('I');
         buffer.writeInt32BE(val, offset); offset += 4;
+        break;
+    case 'unsignedint':
+    case 'uint32':
+        tag('i');
+        buffer.writeUInt32BE(val, offset); offset += 4;
         break;
     case 'long':
     case 'int64':
@@ -247,6 +257,9 @@ function decodeFields(slice) {
         case 'b':
             val = slice.readInt8(offset); offset++;
             break;
+        case 'B':
+            val = slice.readUInt8(offset); offset++;
+            break;
         case 'S':
             len = slice.readUInt32BE(offset); offset += 4;
             val = slice.toString('utf8', offset, offset + len);
@@ -254,6 +267,9 @@ function decodeFields(slice) {
             break;
         case 'I':
             val = slice.readInt32BE(offset); offset += 4;
+            break;
+        case 'i':
+            val = slice.readUInt32BE(offset); offset += 4;
             break;
         case 'D': // only positive decimals, apparently.
             var places = slice[offset]; offset++;


### PR DESCRIPTION
Add support for unsigned int (uint8, uint16, uint32) as specified in https://www.rabbitmq.com/amqp-0-9-1-errata#section_3.

Ignore uint64 to avoid conflict mentionned in #646. 