### PR TITLE
Support for unsigned int edits

### DIFF
--- a/lib/codec.js
+++ b/lib/codec.js
@@ -193,6 +193,10 @@ function encodeFieldValue(buffer, value, offset) {
         tag('s');
         buffer.writeInt16BE(val, offset); offset += 2;
         break;
+    case 'unsignedshort':
+    case 'uint16':
+        tag('u');
+        buffer.writeUInt16BE(val, offset); offset += 2;
     case 'int':
     case 'int32':
         tag('I');
@@ -281,6 +285,9 @@ function decodeFields(slice) {
             break;
         case 's':
             val = slice.readInt16BE(offset); offset += 2;
+            break;
+        case 'u':
+            val = slice.readUInt16BE(offset); offset += 2;
             break;
         case 't':
             val = slice[offset] != 0; offset++;

--- a/lib/codec.js
+++ b/lib/codec.js
@@ -188,6 +188,11 @@ function encodeFieldValue(buffer, value, offset) {
         tag('b');
         buffer.writeInt8(val, offset); offset++;
         break;
+    case 'unsigned byte':
+    case 'uint8':
+        tag('B');
+        buffer.writeUInt8(val, offset); offset++;
+        break;
     case 'short':
     case 'int16':
         tag('s');
@@ -201,6 +206,11 @@ function encodeFieldValue(buffer, value, offset) {
     case 'int32':
         tag('I');
         buffer.writeInt32BE(val, offset); offset += 4;
+        break;
+    case 'unsignedint':
+    case 'uint32':
+        tag('i');
+        buffer.writeUInt32BE(val, offset); offset += 4;
         break;
     case 'long':
     case 'int64':
@@ -247,6 +257,9 @@ function decodeFields(slice) {
         case 'b':
             val = slice.readInt8(offset); offset++;
             break;
+        case 'B':
+            val = slice.readUInt8(offset); offset++;
+            break;
         case 'S':
             len = slice.readUInt32BE(offset); offset += 4;
             val = slice.toString('utf8', offset, offset + len);
@@ -254,6 +267,9 @@ function decodeFields(slice) {
             break;
         case 'I':
             val = slice.readInt32BE(offset); offset += 4;
+            break;
+        case 'i':
+            val = slice.readUInt32BE(offset); offset += 4;
             break;
         case 'D': // only positive decimals, apparently.
             var places = slice[offset]; offset++;

--- a/lib/codec.js
+++ b/lib/codec.js
@@ -188,7 +188,7 @@ function encodeFieldValue(buffer, value, offset) {
         tag('b');
         buffer.writeInt8(val, offset); offset++;
         break;
-    case 'unsigned byte':
+    case 'unsignedbyte':
     case 'uint8':
         tag('B');
         buffer.writeUInt8(val, offset); offset++;
@@ -202,6 +202,7 @@ function encodeFieldValue(buffer, value, offset) {
     case 'uint16':
         tag('u');
         buffer.writeUInt16BE(val, offset); offset += 2;
+        break;
     case 'int':
     case 'int32':
         tag('I');

--- a/test/codec.js
+++ b/test/codec.js
@@ -44,19 +44,16 @@ var testCases = [
     ['null', {'void': null}, [4,118,111,105,100,86]],
 
     // array, object
-    ['array', {array: [6, true, "foo"]},
-     [5,97,114,114,97,121,65,0,0,0,12,98,6,116,1,83,0,0,0,3,102,111,111]],
-    ['object', {object: {foo: "bar", baz: 12}},
-     [6,111,98,106,101,99,116,70,0,0,0,18,3,102,111,111,83,0,
-      0,0,3,98,97,114,3,98,97,122,98,12]],
+    ['array', {array: [6, true, "foo"]},[5,97,114,114,97,121,65,0,0,0,12,98,6,116,1,83,0,0,0,3,102,111,111]],
+    ['object', {object: {foo: "bar", baz: 12}},[6,111,98,106,101,99,116,70,0,0,0,18,3,102,111,111,83,0,0,0,3,98,97,114,3,98,97,122,98,12]],
 
     // exotic types
-    ['timestamp', {timestamp: {'!': 'timestamp', value: 1357212277527}},
-     [9,116,105,109,101,115,116,97,109,112,84,0,0,1,60,0,39,219,23]],
-    ['decimal', {decimal: {'!': 'decimal', value: {digits: 2345, places: 2}}},
-     [7,100,101,99,105,109,97,108,68,2,0,0,9,41]],
-    ['float', {float: {'!': 'float', value: 0.1}},
-     [5,102,108,111,97,116,102,61,204,204,205]],
+    ['timestamp', {timestamp: {'!': 'timestamp', value: 1357212277527}},[9,116,105,109,101,115,116,97,109,112,84,0,0,1,60,0,39,219,23]],
+    ['decimal', {decimal: {'!': 'decimal', value: {digits: 2345, places: 2}}},[7,100,101,99,105,109,97,108,68,2,0,0,9,41]],
+    ['float', {float: {'!': 'float', value: 0.1}},[5,102,108,111,97,116,102,61,204,204,205]],
+    ['unsignedbyte', {unsignedbyte:{'!': 'unsignedbyte', value: 255}}, [12,117,110,115,105,103,110,101,100,98,121,116,101,66,255]],
+    ['unsignedshort', {unsignedshort:{'!': 'unsignedshort', value: 65535}}, [13,117,110,115,105,103,110,101,100,115,104,111,114,116,117,255,255]],
+    ['unsignedint', {unsignedint:{'!': 'unsignedint', value: 4294967295}}, [11,117,110,115,105,103,110,101,100,105,110,116,105,255,255,255,255]],
 ];
 
 function bufferToArray(b) {
@@ -109,6 +106,9 @@ suite("Roundtrip values", function() {
     amqp.Bit,
     amqp.Decimal,
     amqp.Timestamp,
+    amqp.UnsignedByte,
+    amqp.UnsignedShort,
+    amqp.UnsignedInt,
     amqp.Double,
     amqp.Float,
     amqp.FieldArray,

--- a/test/data.js
+++ b/test/data.js
@@ -89,6 +89,18 @@ var Decimal = label('decimal', transform(
   function(args) {
     return {'!': 'decimal', value: {places: args[1], digits: args[0]}};
   }, sequence(arb.UInt, Octet)));
+var UnsignedByte = label('unsignedbyte', transform(
+  function(n) {
+    return {'!': 'unsignedbyte', value: n};
+  }, Octet));
+var UnsignedShort = label('unsignedshort', transform(
+  function(n) {
+    return {'!': 'unsignedshort', value: n};
+  }, UShort));
+var UnsignedInt = label('unsignedint', transform(
+  function(n) {
+    return {'!': 'unsignedint', value: n};
+  }, ULong));
 
 // Signed 8 bit int
 var Byte = rangeInt('byte', -128, 127);
@@ -244,6 +256,9 @@ module.exports = {
   Float: Float,
   Timestamp: Timestamp,
   Decimal: Decimal,
+  UnsignedByte: UnsignedByte,
+  UnsignedShort: UnsignedShort,
+  UnsignedInt: UnsignedInt,
   FieldArray: FieldArray,
   FieldTable: FieldTable,
 


### PR DESCRIPTION
This PR completes the work started by @ebrinette in https://github.com/amqp-node/amqplib/pull/766. The noteable changes are...

1. Add missing break statement
2. Change 'unsigned byte' to 'unsignedbyte'
3. Add tests