### PR TITLE
Support U tag for signed 16bit field values

### DIFF
--- a/lib/codec.js
+++ b/lib/codec.js
@@ -300,6 +300,7 @@ function decodeFields(slice) {
         case 'l':
             val = ints.readInt64BE(slice, offset); offset += 8;
             break;
+        case 'U':
         case 's':
             val = slice.readInt16BE(offset); offset += 2;
             break;


### PR DESCRIPTION
See https://github.com/amqp-node/amqplib/pull/620 (couldn't merge because it would have created a duplicate tag for 'u')