### PR TITLE
dont check frame max size when parse

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -553,7 +553,7 @@ class Connection extends EventEmitter {
 
   recvFrame () {
     // %%% identifying invariants might help here?
-    var frame = parseFrame(this.rest, this.frameMax);
+    var frame = parseFrame(this.rest);
 
     if (!frame) {
       var incoming = this.stream.read();

--- a/lib/frame.js
+++ b/lib/frame.js
@@ -47,14 +47,11 @@ module.exports.makeBodyFrame = function(channel, payload) {
 var frameHeaderPattern = Bits.matcher('type:8', 'channel:16',
                                       'size:32', 'rest/binary');
 
-function parseFrame(bin, max) {
+function parseFrame(bin) {
   var fh = frameHeaderPattern(bin);
   if (fh) {
     var size = fh.size, rest = fh.rest;
-    if (size > max) {
-      throw new Error('Frame size exceeds frame max');
-    }
-    else if (rest.length > size) {
+    if (rest.length > size) {
       if (rest[size] !== FRAME_END)
         throw new Error('Invalid frame');
 

--- a/test/frame.js
+++ b/test/frame.js
@@ -69,12 +69,6 @@ suite("Explicit parsing", function() {
                   0,0,0,0, // garbage ID
                   defs.constants.FRAME_END]);
 
-  testBogusFrame('> max frame',
-                 [defs.constants.FRAME_BODY,
-                  0,0, 0,0,0,6, // too big!
-                  65,66,67,68,69,70,
-                  defs.constants.FRAME_END]);
-
 });
 
 // Now for a bit more fun.


### PR DESCRIPTION

When you first saw this you must have thought I was crazy and wanted to close this pr immediately, but I would like to ask you to bear with me and listen to my reasons!


I understand that the AMQP 0-9-1 protocol requires that the server and client must respect frame max


 > frame-max: the largest frame size that the server proposes for the connection. The client can negotiate a lower value. Zero means that the server does not impose any specific limit but may reject very large frames for internal reasons.

> Once negotiated, both parties MUST NOT send frames exceeding this size.

>	When a message is too large to fit within a single frame, it must be split into multiple frames.




However, in reality, some cloud server vendors do not necessarily comply with this specification for cost reasons, such as `alibabacloud` [https://www.alibabacloud.com/en/product/rabbitmq?plc=1](https://www.alibabacloud.com/en/product/rabbitmq?plc=1), whatever you set frame max, the server never spilt frame, even they said frame size 0x8000 when tune.

You may be in disbelief, why would they dare to do this? But in fact, most AMQP libraries are tolerant of this, especially the official Java library of RabbitMQ.


```java
    private void consumeHeaderFrame(Frame f) throws IOException {
        if (f.getType() == AMQP.FRAME_HEADER) {
            this.contentHeader = AMQImpl.readContentHeaderFrom(f.getInputStream());
            long bodySize = this.contentHeader.getBodySize();
            if (bodySize >= this.maxBodyLength) {
                throw new IllegalStateException(format(
                    "Message body is too large (%d), maximum configured size is %d. " +
                        "See ConnectionFactory#setMaxInboundMessageBodySize " +
                        "if you need to increase the limit.",
                    bodySize, this.maxBodyLength
                ));
            }
            this.remainingBodyBytes = bodySize;
            updateContentBodyState();
        } else {
            throw new UnexpectedFrameError(f, AMQP.FRAME_HEADER);
        }
    }
```


https://github.com/rabbitmq/rabbitmq-java-client/blob/d5b8b673768379e42056a27f5dd8c0e9bda64812/src/main/java/com/rabbitmq/client/impl/CommandAssembler.java#L104-L108

Another nodejs library does the same.

```ts
export async function decodeFrame(read: (bytes: number) => Promise<Buffer>): Promise<DataFrame> {
  const chunk = await read(7)
  const frameTypeId = chunk.readUint8(0)
  const channelId = chunk.readUint16BE(1)
  const frameSize = chunk.readUint32BE(3)
  const payloadBuffer = await read(frameSize + 1)
  if (payloadBuffer[frameSize] !== FRAME_END)
    throw new AMQPConnectionError('FRAME_ERROR', 'invalid FRAME_END octet: ' + payloadBuffer[frameSize])
  if (frameTypeId === FrameType.METHOD) {
```

https://github.com/cody-greene/node-rabbitmq-client/blob/c44a4b48c03d5a43f9d98e1979246bebd62143bc/src/codec.ts#L696C1-L704C42


