### PR TITLE
Feature/drop using bitsyntax pkg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ RABBITMQ_SRC_VERSION=v3.12.13
 JSON=amqp-rabbitmq-0.9.1.json
 AMQP_JSON=https://raw.githubusercontent.com/rabbitmq/rabbitmq-server/$(RABBITMQ_SRC_VERSION)/deps/rabbitmq_codegen/$(JSON)
 
-NODEJS_VERSIONS='12.18' '13.14' '14.5' '15.8' '16.3.0' '18.1.0' '20.10.0' '22.14.0'
+NODEJS_VERSIONS='10.21' '11.15' '12.18' '13.14' '14.5' '15.8' '16.3.0' '18.1.0' '20.10.0' '22.14.0'
 
 MOCHA=./node_modules/.bin/mocha
 _MOCHA=./node_modules/.bin/_mocha

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ RABBITMQ_SRC_VERSION=v3.12.13
 JSON=amqp-rabbitmq-0.9.1.json
 AMQP_JSON=https://raw.githubusercontent.com/rabbitmq/rabbitmq-server/$(RABBITMQ_SRC_VERSION)/deps/rabbitmq_codegen/$(JSON)
 
-NODEJS_VERSIONS='10.21' '11.15' '12.18' '13.14' '14.5' '15.8' '16.3.0' '18.1.0' '20.10.0'
+NODEJS_VERSIONS='12.18' '13.14' '14.5' '15.8' '16.3.0' '18.1.0' '20.10.0' '22.14.0'
 
 MOCHA=./node_modules/.bin/mocha
 _MOCHA=./node_modules/.bin/_mocha

--- a/lib/frame.js
+++ b/lib/frame.js
@@ -60,7 +60,7 @@ function readInt64BE(buffer, offset) {
    * We try to use native implementation if available here because
    * buffer-more-ints does not
    */
-  if (Buffer.prototype.readBigInt64BE) {
+  if (typeof Buffer.prototype.readBigInt64BE === 'function') {
     return Number(buffer.readBigInt64BE(offset))
   }
 

--- a/lib/frame.js
+++ b/lib/frame.js
@@ -4,6 +4,7 @@
 
 'use strict';
 
+const ints = require('buffer-more-ints')
 var defs = require('./defs');
 var constants = defs.constants;
 var decode = defs.decode;
@@ -31,11 +32,50 @@ FRAME_HEADER = constants.FRAME_HEADER,
 FRAME_BODY = constants.FRAME_BODY,
 FRAME_END = constants.FRAME_END;
 
+// expected byte sizes for frame parts
+const TYPE_BYTES = 1
+const CHANNEL_BYTES = 2
+const SIZE_BYTES = 4
+const FRAME_HEADER_BYTES = TYPE_BYTES + CHANNEL_BYTES + SIZE_BYTES
+const FRAME_END_BYTES = 1
+
+/**
+ * @typedef {{
+ *   type: number,
+ *   channel: number,
+ *   size: number,
+ *   payload: Buffer,
+ *   rest: Buffer
+ * }} FrameStructure
+ */
+
+/**
+ * This is a polyfill which will read a big int 64 bit as a number.
+ * @arg { Buffer } buffer
+ * @arg { number } offset
+ * @returns { number }
+ */
+function readInt64BE(buffer, offset) {
+  /**
+   * We try to use native implementation if available here because
+   * buffer-more-ints does not
+   */
+  if (Buffer.prototype.readBigInt64BE) {
+    return Number(buffer.readBigInt64BE(offset))
+  }
+
+  return ints.readInt64BE(buffer, offset)
+}
+
 // %%% TESTME possibly better to cons the first bit and write the
 // second directly, in the absence of IO lists
+/**
+ * Make a frame header
+ * @arg { number } channel
+ * @arg { Buffer } payload
+ */
 module.exports.makeBodyFrame = function (channel, payload) {
-  // 1 byte for type, 2 bytes for channel, 4 bytes for size, payload size and 1 for frame-end
-  const frameSize = 8 + payload.length
+  const frameSize = FRAME_HEADER_BYTES + payload.length + FRAME_END_BYTES
 
   const frame = Buffer.alloc(frameSize)
 
@@ -55,10 +95,14 @@ module.exports.makeBodyFrame = function (channel, payload) {
 
 /**
  * Parse an AMQP frame
- * @arg {Buffer} bin
+ * @arg { Buffer } bin
+ * @arg { number } max
+ * @returns { FrameStructure | boolean }
  */
 function parseFrame(bin, max) {
-  if (bin.length < 7) return false
+  if (bin.length < FRAME_HEADER_BYTES) {
+    return false
+  }
 
   const type = bin.readUInt8(0)
   const channel = bin.readUInt16BE(1)
@@ -68,14 +112,13 @@ function parseFrame(bin, max) {
     throw new Error('Frame size exceeds frame max');
   }
 
-  // The total size of the frame is the size of the payload + the header + the frame-end
-  const totalSize = size + 8
+  const totalSize = FRAME_HEADER_BYTES + size + FRAME_END_BYTES
 
   if (bin.length < totalSize) {
     return false
   }
 
-  const frameEnd = bin.readUInt8(7 + size)
+  const frameEnd = bin.readUInt8(FRAME_HEADER_BYTES + size)
 
   if (frameEnd !== FRAME_END) {
     throw new Error('Invalid frame')
@@ -85,7 +128,7 @@ function parseFrame(bin, max) {
     type,
     channel,
     size,
-    payload: bin.subarray(7, 7 + size),
+    payload: bin.subarray(FRAME_HEADER_BYTES, FRAME_HEADER_BYTES + size),
     rest: bin.subarray(totalSize)
   }
 }
@@ -94,8 +137,12 @@ module.exports.parseFrame = parseFrame;
 
 var HEARTBEAT = {channel: 0};
 
+/**
+ * Decode AMQP frame into JS object
+ * @param { FrameStructure } frame
+ * @returns
+ */
 module.exports.decodeFrame = (frame) => {
-  /** @type { Buffer } */
   const payload = frame.payload
   const channel = frame.channel
 
@@ -109,7 +156,7 @@ module.exports.decodeFrame = (frame) => {
     case FRAME_HEADER: {
       const id = payload.readUInt16BE(0)
       // const weight = payload.readUInt16BE(2)
-      const size = Number(payload.readBigInt64BE(4))
+      const size = readInt64BE(payload, 4)
       const flagsAndfields = payload.subarray(12)
       const fields = decode(id, flagsAndfields)
       return { id, channel, size, fields }

--- a/lib/frame.js
+++ b/lib/frame.js
@@ -8,8 +8,6 @@ var defs = require('./defs');
 var constants = defs.constants;
 var decode = defs.decode;
 
-var Bits = require('@acuminous/bitsyntax');
-
 module.exports.PROTOCOL_HEADER = "AMQP" + String.fromCharCode(0, 0, 9, 1);
 
 /*
@@ -55,63 +53,73 @@ module.exports.makeBodyFrame = function (channel, payload) {
   return frame
 };
 
-var frameHeaderPattern = Bits.matcher('type:8', 'channel:16',
-                                      'size:32', 'rest/binary');
-
+/**
+ * Parse an AMQP frame
+ * @arg {Buffer} bin
+ */
 function parseFrame(bin, max) {
-  var fh = frameHeaderPattern(bin);
-  if (fh) {
-    var size = fh.size, rest = fh.rest;
-    if (size > max) {
-      throw new Error('Frame size exceeds frame max');
-    }
-    else if (rest.length > size) {
-      if (rest[size] !== FRAME_END)
-        throw new Error('Invalid frame');
+  if (bin.length < 7) return false
 
-      return {
-        type: fh.type,
-        channel: fh.channel,
-        size: size,
-        payload: rest.slice(0, size),
-        rest: rest.slice(size + 1)
-      };
-    }
+  const type = bin.readUInt8(0)
+  const channel = bin.readUInt16BE(1)
+  const size = bin.readUInt32BE(3)
+
+  if (size > max) {
+    throw new Error('Frame size exceeds frame max');
   }
-  return false;
+
+  // The total size of the frame is the size of the payload + the header + the frame-end
+  const totalSize = size + 8
+
+  if (bin.length < totalSize) {
+    return false
+  }
+
+  const frameEnd = bin.readUInt8(7 + size)
+
+  if (frameEnd !== FRAME_END) {
+    throw new Error('Invalid frame')
+  }
+
+  return {
+    type,
+    channel,
+    size,
+    payload: bin.subarray(7, 7 + size),
+    rest: bin.subarray(totalSize)
+  }
 }
 
 module.exports.parseFrame = parseFrame;
 
-var headerPattern = Bits.matcher('class:16',
-                                 '_weight:16',
-                                 'size:64',
-                                 'flagsAndfields/binary');
-
-var methodPattern = Bits.matcher('id:32, args/binary');
-
 var HEARTBEAT = {channel: 0};
 
-module.exports.decodeFrame = function(frame) {
-  var payload = frame.payload;
+module.exports.decodeFrame = (frame) => {
+  /** @type { Buffer } */
+  const payload = frame.payload
+  const channel = frame.channel
+
   switch (frame.type) {
-  case FRAME_METHOD:
-    var idAndArgs = methodPattern(payload);
-    var id = idAndArgs.id;
-    var fields = decode(id, idAndArgs.args);
-    return {id: id, channel: frame.channel, fields: fields};
-  case FRAME_HEADER:
-    var parts = headerPattern(payload);
-    var id = parts['class'];
-    var fields = decode(id, parts.flagsAndfields);
-    return {id: id, channel: frame.channel,
-            size: parts.size, fields: fields};
-  case FRAME_BODY:
-    return {channel: frame.channel, content: frame.payload};
-  case FRAME_HEARTBEAT:
-    return HEARTBEAT;
-  default:
-    throw new Error('Unknown frame type ' + frame.type);
+    case FRAME_METHOD: {
+      const id = payload.readUInt32BE(0)
+      const args = payload.subarray(4)
+      const fields = decode(id, args)
+      return { id, channel, fields }
+    }
+    case FRAME_HEADER: {
+      const id = payload.readUInt16BE(0)
+      // const weight = payload.readUInt16BE(2)
+      const size = Number(payload.readBigInt64BE(4))
+      const flagsAndfields = payload.subarray(12)
+      const fields = decode(id, flagsAndfields)
+      return { id, channel, size, fields }
+    }
+    case FRAME_BODY:
+      return { channel, content: payload }
+    case FRAME_HEARTBEAT:
+      return HEARTBEAT
+    default:
+      throw new Error('Unknown frame type ' + frame.type)
   }
 }
 

--- a/lib/frame.js
+++ b/lib/frame.js
@@ -33,15 +33,26 @@ FRAME_HEADER = constants.FRAME_HEADER,
 FRAME_BODY = constants.FRAME_BODY,
 FRAME_END = constants.FRAME_END;
 
-var bodyCons =
-  Bits.builder(FRAME_BODY,
-               'channel:16, size:32, payload:size/binary',
-               FRAME_END);
-
 // %%% TESTME possibly better to cons the first bit and write the
 // second directly, in the absence of IO lists
-module.exports.makeBodyFrame = function(channel, payload) {
-  return bodyCons({channel: channel, size: payload.length, payload: payload});
+module.exports.makeBodyFrame = function (channel, payload) {
+  // 1 byte for type, 2 bytes for channel, 4 bytes for size, payload size and 1 for frame-end
+  const frameSize = 8 + payload.length
+
+  const frame = Buffer.alloc(frameSize)
+
+  let offset = 0
+
+  offset = frame.writeUInt8(FRAME_BODY, offset)
+  offset = frame.writeUInt16BE(channel, offset)
+  offset = frame.writeInt32BE(payload.length, offset)
+
+  payload.copy(frame, offset)
+  offset += payload.length
+
+  frame.writeUInt8(FRAME_END, offset)
+
+  return frame
 };
 
 var frameHeaderPattern = Bits.matcher('type:8', 'channel:16',

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.10.5",
       "license": "MIT",
       "dependencies": {
-        "@acuminous/bitsyntax": "^0.1.2",
         "buffer-more-ints": "~1.0.0",
         "url-parse": "~1.5.10"
       },
@@ -21,19 +20,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@acuminous/bitsyntax": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@acuminous/bitsyntax/-/bitsyntax-0.1.2.tgz",
-      "integrity": "sha512-29lUK80d1muEQqiUsSo+3A0yP6CdspgC95EnKBMi22Xlwt79i/En4Vr67+cXhU+cZjbti3TgGGC5wy1stIywVQ==",
-      "dependencies": {
-        "buffer-more-ints": "~1.0.0",
-        "debug": "^4.3.4",
-        "safe-buffer": "~5.1.2"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -821,6 +807,7 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -1885,7 +1872,8 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "node_modules/nanoid": {
       "version": "3.3.1",
@@ -2320,7 +2308,8 @@
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "node_modules/semver": {
       "version": "6.3.0",
@@ -2806,16 +2795,6 @@
     }
   },
   "dependencies": {
-    "@acuminous/bitsyntax": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@acuminous/bitsyntax/-/bitsyntax-0.1.2.tgz",
-      "integrity": "sha512-29lUK80d1muEQqiUsSo+3A0yP6CdspgC95EnKBMi22Xlwt79i/En4Vr67+cXhU+cZjbti3TgGGC5wy1stIywVQ==",
-      "requires": {
-        "buffer-more-ints": "~1.0.0",
-        "debug": "^4.3.4",
-        "safe-buffer": "~5.1.2"
-      }
-    },
     "@ampproject/remapping": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
@@ -3421,6 +3400,7 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -4186,7 +4166,8 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "nanoid": {
       "version": "3.3.1",
@@ -4520,7 +4501,8 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "semver": {
       "version": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "node": ">=10"
   },
   "dependencies": {
-    "@acuminous/bitsyntax": "^0.1.2",
     "buffer-more-ints": "~1.0.0",
     "url-parse": "~1.5.10"
   },


### PR DESCRIPTION
Drop using @acuminous/bitsyntax because it's incompatible with --disallow-code-generation-from-strings node flag, and there is no heavy bit parsing logic which cannot be replaced with some simple code