### PR TITLE
Use a frame_max of 131072 by default for RabbitMQ 4.1.0 compatibility

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -66,7 +66,7 @@ function openFrames(vhost, query, credentials, extraClientProperties) {
 
     // tune-ok
     'channelMax': intOrDefault(query.channelMax, 0),
-    'frameMax': intOrDefault(query.frameMax, 0x1000),
+    'frameMax': intOrDefault(query.frameMax, 131072),
     'heartbeat': intOrDefault(query.heartbeat, 0),
 
     // open


### PR DESCRIPTION
Just like nearly all client libraries do.

In RabbitMQ 4.1.0, the pre-authentication default changes to 8192 to accommodate for larger JWT frames, which the current value in this client won't be compatible with. See [1].

This default matches what RabbitMQ itself, the Java and .NET clients have been using since 2007.

1. https://github.com/rabbitmq/rabbitmq-server/blob/main/release-notes/4.1.0.md#initial-amqp-0-9-1-maximum-frame-size