### PR TITLE
Modernisation 3 - Enable noUnusedFunctionParameters lint rule and fix violations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add automated formatting via pre-commit hooks using Lefthook
 - Format entire codebase with standardised formatting rules
 - Add npm format script for manual code formatting
+- Enable noUnusedFunctionParameters lint rule and fix all violations
 
 ## v0.10.9
 - Add support for IPv6 urls

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,12 @@
+# Project-Specific Guidelines for amqplib
+
+## Generated Files - DO NOT EDIT
+- `lib/defs.js` - This file is generated code. NEVER modify it directly.
+  - Generated via `make lib/defs.js` from the AMQP specification
+  - If linting issues arise, exclude this file from linting rules rather than modifying it
+
+## Commit Requirements
+- NEVER commit when tests are failing
+- NEVER commit when there are lint errors
+- Always run `npm test` and `npm run lint` before committing
+- If tests are failing, investigate and fix the issue before proceeding

--- a/biome.json
+++ b/biome.json
@@ -20,7 +20,7 @@
         "useLiteralKeys": "off"
       },
       "correctness": {
-        "noUnusedFunctionParameters": "off",
+        "noUnusedFunctionParameters": "error",
         "noUnusedVariables": "off",
         "noInnerDeclarations": "off",
         "useParseIntRadix": "off",
@@ -59,6 +59,6 @@
     }
   },
   "files": {
-    "includes": ["**/*.js"]
+    "includes": ["**/*.js", "!lib/defs.js"]
   }
 }

--- a/examples/tutorials/callback_api/receive_logs.js
+++ b/examples/tutorials/callback_api/receive_logs.js
@@ -15,7 +15,7 @@ amqp.connect((err, connection) => {
       });
     });
 
-    channel.assertExchange(exchange, 'fanout', {durable: false}, (err, {queue}) => {
+    channel.assertExchange(exchange, 'fanout', {durable: false}, (err, {queue: _queue}) => {
       if (err) return bail(err, connection);
       channel.assertQueue('', {exclusive: true}, (err, {queue}) => {
         if (err) return bail(err, connection);

--- a/lib/callback_model.js
+++ b/lib/callback_model.js
@@ -35,7 +35,7 @@ class CallbackModel extends EventEmitter {
     }
     var ch = new Channel(this.connection);
     ch.setOptions(options);
-    ch.open(function (err, ok) {
+    ch.open(function (err, _ok) {
       if (err === null) cb && cb(null, ch);
       else cb && cb(err);
     });
@@ -244,7 +244,7 @@ class Channel extends BaseChannel {
 // values. Also substitutes a stub if the callback is `undefined` or
 // otherwise falsey, for convenience in methods for which the callback
 // is optional (that is, most of them).
-function callbackWrapper(ch, cb) {
+function callbackWrapper(_ch, cb) {
   return cb
     ? function (err, ok) {
         if (err === null) {

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -47,7 +47,7 @@ function openFrames(vhost, query, credentials, extraClientProperties) {
   if (!vhost) vhost = '/';
   else vhost = QS.unescape(vhost);
 
-  var query = query || {};
+  query = query || {};
 
   function intOrDefault(val, def) {
     return val === undefined ? def : parseInt(val);
@@ -147,7 +147,7 @@ function connect(url, socketOptions, openCallback) {
     if (keepAlive) sock.setKeepAlive(keepAlive, keepAliveDelay);
 
     var c = new Connection(sock);
-    c.open(fields, function (err, ok) {
+    c.open(fields, function (err, _ok) {
       // disable timeout once the connection is open, we don't want
       // it fouling things
       if (timeout) sock.setTimeout(0);

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "test": "make test",
     "format": "biome format . --write",
-    "lint": "biome lint ."
+    "lint": "biome lint --max-diagnostics=1000 ."
   },
   "keywords": [
     "AMQP",

--- a/test/callback_api.js
+++ b/test/callback_api.js
@@ -100,7 +100,7 @@ var channel_test = channel_test_fn('createChannel');
 var confirm_channel_test = channel_test_fn('createConfirmChannel');
 
 suite('channel open', function () {
-  channel_test('at all', function (ch, done) {
+  channel_test('at all', function (_ch, done) {
     done();
   });
 
@@ -114,10 +114,10 @@ suite('assert, check, delete', function () {
     ch.assertQueue(
       'test.cb.queue',
       {},
-      kCallback(function (q) {
+      kCallback(function (_q) {
         ch.checkQueue(
           'test.cb.queue',
-          kCallback(function (ok) {
+          kCallback(function (_ok) {
             ch.deleteQueue('test.cb.queue', {}, doneCallback(done));
           }, done),
         );
@@ -130,10 +130,10 @@ suite('assert, check, delete', function () {
       'test.cb.exchange',
       'topic',
       {},
-      kCallback(function (ex) {
+      kCallback(function (_ex) {
         ch.checkExchange(
           'test.cb.exchange',
-          kCallback(function (ok) {
+          kCallback(function (_ok) {
             ch.deleteExchange('test.cb.exchange', {}, doneCallback(done));
           }, done),
         );
@@ -335,7 +335,7 @@ suite('Error handling', function () {
       var dom = domain.createDomain();
       dom.on('error', failCallback(done));
       connect(
-        dom.bind(function (err, conn) {
+        dom.bind(function (_err, _conn) {
           throw new Error('Spurious connection open callback error');
         }),
       );
@@ -366,21 +366,21 @@ suite('Error handling', function () {
     });
   }
 
-  error_test('Channel open callback throws an error', function (ch, done, dom) {
+  error_test('Channel open callback throws an error', function (_ch, done, dom) {
     dom.on('error', failCallback(done));
     throw new Error('Error in open callback');
   });
 
   error_test('RPC callback throws error', function (ch, done, dom) {
     dom.on('error', failCallback(done));
-    ch.prefetch(0, false, function (err, ok) {
+    ch.prefetch(0, false, function (_err, _ok) {
       throw new Error('Spurious callback error');
     });
   });
 
   error_test('Get callback throws error', function (ch, done, dom) {
     dom.on('error', failCallback(done));
-    ch.assertQueue('test.cb.get-with-error', {}, function (err, ok) {
+    ch.assertQueue('test.cb.get-with-error', {}, function (_err, _ok) {
       ch.get('test.cb.get-with-error', {noAck: true}, function () {
         throw new Error('Spurious callback error');
       });
@@ -389,7 +389,7 @@ suite('Error handling', function () {
 
   error_test('Consume callback throws error', function (ch, done, dom) {
     dom.on('error', failCallback(done));
-    ch.assertQueue('test.cb.consume-with-error', {}, function (err, ok) {
+    ch.assertQueue('test.cb.consume-with-error', {}, function (_err, _ok) {
       ch.consume('test.cb.consume-with-error', ignore, {noAck: true}, function () {
         throw new Error('Spurious callback error');
       });

--- a/test/channel.js
+++ b/test/channel.js
@@ -25,7 +25,7 @@ function baseChannelTest(client, server) {
 
     if (LOG_ERRORS) c.on('error', console.warn);
 
-    c.open(OPEN_OPTS, function (err, ok) {
+    c.open(OPEN_OPTS, function (err, _ok) {
       if (err === null) client(c, bothDone);
       else fail(bothDone);
     });
@@ -90,7 +90,7 @@ suite('channel open and close', function () {
       function (ch, done) {
         open(ch).then(succeed(done), fail(done));
       },
-      function (send, wait, done) {
+      function (_send, _wait, done) {
         done();
       },
     ),
@@ -127,7 +127,7 @@ suite('channel open and close', function () {
       },
       function (send, wait, done, ch) {
         return wait(defs.ChannelClose)()
-          .then(function (close) {
+          .then(function (_close) {
             send(defs.ChannelCloseOk, {}, ch);
           })
           .then(succeed(done), fail(done));
@@ -174,7 +174,7 @@ suite('channel open and close', function () {
           ch.closeBecause('Bye', defs.constants.REPLY_SUCCESS);
         }, fail(both));
       },
-      function (send, wait, done, ch) {
+      function (send, wait, done, _ch) {
         wait(defs.ChannelClose)()
           .then(function () {
             send(
@@ -227,7 +227,7 @@ suite('channel machinery', function () {
         var rpcLatch = latch(3, done);
         open(ch)
           .then(function () {
-            function wheeboom(err, f) {
+            function wheeboom(err, _f) {
               if (err !== null) rpcLatch(err);
               else rpcLatch();
             }
@@ -245,7 +245,7 @@ suite('channel machinery', function () {
           .then(null, fail(rpcLatch));
       },
       function (send, wait, done, ch) {
-        function sendOk(f) {
+        function sendOk(_f) {
           send(defs.BasicQosOk, {}, ch);
         }
 
@@ -368,7 +368,7 @@ suite('channel machinery', function () {
           })
           .then(succeed(done), fail(done));
       },
-      function (send, wait, done, ch) {
+      function (_send, wait, done, _ch) {
         wait(defs.BasicPublish)()
           .then(wait(defs.BasicProperties))
           .then(wait(undefined)) // content frame
@@ -399,7 +399,7 @@ suite('channel machinery', function () {
           );
         }, done);
       },
-      function (send, wait, done, ch) {
+      function (_send, wait, done, _ch) {
         wait(defs.BasicPublish)()
           .then(wait(defs.BasicProperties))
           .then(wait(undefined)) // content frame
@@ -432,7 +432,7 @@ suite('channel machinery', function () {
           );
         }, done);
       },
-      function (send, wait, done, ch) {
+      function (_send, wait, done, _ch) {
         wait(defs.BasicPublish)()
           .then(wait(defs.BasicProperties))
           .then(wait(undefined)) // content frame
@@ -474,7 +474,7 @@ suite('channel machinery', function () {
           );
         }, done);
       },
-      function (send, wait, done, ch) {
+      function (_send, wait, done, _ch) {
         wait(defs.BasicPublish)()
           .then(wait(defs.BasicProperties))
           // no content frame for a zero-length message
@@ -495,7 +495,7 @@ suite('channel machinery', function () {
           }, done);
         });
       },
-      function (send, wait, done, ch) {
+      function (send, _wait, done, ch) {
         completes(function () {
           send(defs.BasicDeliver, DELIVER_FIELDS, ch, Buffer.from('barfoo'));
         }, done);
@@ -514,7 +514,7 @@ suite('channel machinery', function () {
           }, done);
         });
       },
-      function (send, wait, done, ch) {
+      function (send, _wait, done, ch) {
         completes(function () {
           send(defs.BasicDeliver, DELIVER_FIELDS, ch, Buffer.from(''));
         }, done);
@@ -560,7 +560,7 @@ suite('channel machinery', function () {
           });
         }, done);
       },
-      function (send, wait, done, ch) {
+      function (_send, _wait, done, _ch) {
         done();
       },
     ),
@@ -577,7 +577,7 @@ suite('channel machinery', function () {
           });
         }, done);
       },
-      function (send, wait, done, ch) {
+      function (_send, _wait, done, _ch) {
         done();
       },
     ),
@@ -654,7 +654,7 @@ suite('channel machinery', function () {
         });
         open(ch);
       },
-      function (send, wait, done, ch) {
+      function (send, _wait, done, ch) {
         completes(function () {
           send(defs.BasicReturn, DELIVER_FIELDS, ch, Buffer.from('barfoo'));
         }, done);
@@ -673,7 +673,7 @@ suite('channel machinery', function () {
         });
         open(ch);
       },
-      function (send, wait, done, ch) {
+      function (send, _wait, done, ch) {
         completes(function () {
           send(
             defs.BasicCancel,
@@ -700,7 +700,7 @@ suite('channel machinery', function () {
           });
           open(ch);
         },
-        function (send, wait, done, ch) {
+        function (send, _wait, done, ch) {
           completes(function () {
             send(
               Method,
@@ -734,7 +734,7 @@ suite('channel machinery', function () {
         ch.pushConfirmCallback(allConfirms);
         open(ch);
       },
-      function (send, wait, done, ch) {
+      function (send, _wait, done, ch) {
         completes(function () {
           send(defs.BasicAck, {deliveryTag: 2, multiple: false}, ch);
           send(defs.BasicAck, {deliveryTag: 3, multiple: false}, ch);
@@ -761,7 +761,7 @@ suite('channel machinery', function () {
         });
         open(ch);
       },
-      function (send, wait, done, ch) {
+      function (send, _wait, done, ch) {
         completes(function () {
           send(defs.BasicAck, {deliveryTag: 2, multiple: false}, ch);
           send(defs.BasicAck, {deliveryTag: 1, multiple: false}, ch);

--- a/test/channel_api.js
+++ b/test/channel_api.js
@@ -85,7 +85,7 @@ var EX_OPTS = {durable: false};
 
 suite('assert, check, delete', function () {
   chtest('assert and check queue', function (ch) {
-    return ch.assertQueue('test.check-queue', QUEUE_OPTS).then(function (qok) {
+    return ch.assertQueue('test.check-queue', QUEUE_OPTS).then(function (_qok) {
       return ch.checkQueue('test.check-queue');
     });
   });
@@ -154,7 +154,7 @@ suite('assert, check, delete', function () {
 function waitForQueue(q, condition) {
   return connect(URL).then(function (c) {
     return c.createChannel().then(function (ch) {
-      return ch.checkQueue(q).then(function (qok) {
+      return ch.checkQueue(q).then(function (_qok) {
         function check() {
           return ch.checkQueue(q).then(function (qok) {
             if (condition(qok)) {
@@ -380,7 +380,7 @@ suite('binding, consuming', function () {
   chtest('cancel consumer', function (ch) {
     var q = 'test.consumer-cancel';
     var ctag;
-    var recv1 = new Promise(function (resolve, reject) {
+    var recv1 = new Promise(function (resolve, _reject) {
       Promise.all([
         ch.assertQueue(q, QUEUE_OPTS),
         ch.purgeQueue(q),

--- a/test/connect.js
+++ b/test/connect.js
@@ -131,7 +131,7 @@ suite('Connect API', function () {
   });
 
   test('ipv6', function (done) {
-    connect('amqp://[::1]', {}, function (err, connection) {
+    connect('amqp://[::1]', {}, function (err, _connection) {
       if (err) {
         return done(err);
       }
@@ -152,7 +152,7 @@ suite('Connect API', function () {
   test('with a given connection timeout', function (done) {
     var timeoutServer = net.createServer(function () {}).listen(31991);
 
-    connect('amqp://localhost:31991', {timeout: 50}, function (err, val) {
+    connect('amqp://localhost:31991', {timeout: 50}, function (_err, val) {
       timeoutServer.close();
       if (val) done(new Error('Expected connection timeout, did not'));
       else done();

--- a/test/connection.js
+++ b/test/connection.js
@@ -43,12 +43,12 @@ function happy_open(send, wait) {
     locales: Buffer.from('en_US'),
   });
   return wait(defs.ConnectionStartOk)()
-    .then(function (f) {
+    .then(function (_f) {
       send(defs.ConnectionTune, {channelMax: 0, heartbeat: 0, frameMax: 0});
     })
     .then(wait(defs.ConnectionTuneOk))
     .then(wait(defs.ConnectionOpen))
-    .then(function (f) {
+    .then(function (_f) {
       send(defs.ConnectionOpenOk, {knownHosts: ''});
     });
 }
@@ -114,7 +114,7 @@ suite('Connection open', function () {
       function (c, done) {
         c.open(OPEN_OPTS, kCallback(fail(done), succeed(done)));
       },
-      function (send, wait, done) {
+      function (send, _wait, done) {
         // bad server! bad! whatever were you thinking?
         completes(function () {
           send(defs.ConnectionTune, {channelMax: 0, heartbeat: 0, frameMax: 0});
@@ -164,7 +164,7 @@ suite('Connection running', function () {
             send(defs.ChannelOpenOk, {channelId: Buffer.from('')}, 0);
           })
           .then(wait(defs.ConnectionClose))
-          .then(function (close) {
+          .then(function (_close) {
             send(defs.ConnectionCloseOk, {}, 0);
           })
           .then(succeed(done), fail(done));
@@ -188,7 +188,7 @@ suite('Connection running', function () {
             send(defs.ChannelOpenOk, {channelId: Buffer.from('')}, 3);
           })
           .then(wait(defs.ConnectionClose))
-          .then(function (close) {
+          .then(function (_close) {
             send(defs.ConnectionCloseOk, {}, 0);
           })
           .then(succeed(done), fail(done));
@@ -228,7 +228,7 @@ suite('Connection running', function () {
         c.on('blocked', succeed(done));
         c.open(OPEN_OPTS);
       },
-      function (send, wait, done, socket) {
+      function (send, wait, done, _socket) {
         happy_open(send, wait)
           .then(function () {
             send(defs.ConnectionBlocked, {reason: 'felt like it'}, 0);
@@ -245,7 +245,7 @@ suite('Connection running', function () {
         c.on('unblocked', succeed(done));
         c.open(OPEN_OPTS);
       },
-      function (send, wait, done, socket) {
+      function (send, wait, done, _socket) {
         happy_open(send, wait)
           .then(function () {
             send(defs.ConnectionUnblocked, {}, 0);
@@ -276,7 +276,7 @@ suite('Connection close', function () {
       function (send, wait, done) {
         happy_open(send, wait)
           .then(wait(defs.ConnectionClose))
-          .then(function (close) {
+          .then(function (_close) {
             send(defs.ConnectionCloseOk, {});
           })
           .then(succeed(done), fail(done));
@@ -300,7 +300,7 @@ suite('Connection close', function () {
       function (send, wait, done) {
         happy_open(send, wait)
           .then(wait(defs.ConnectionClose))
-          .then(function (f) {
+          .then(function (_f) {
             send(defs.ConnectionClose, {
               replyText: 'Ha!',
               replyCode: defs.constants.REPLY_SUCCESS,
@@ -309,7 +309,7 @@ suite('Connection close', function () {
             });
           })
           .then(wait(defs.ConnectionCloseOk))
-          .then(function (f) {
+          .then(function (_f) {
             send(defs.ConnectionCloseOk, {});
           })
           .then(succeed(done), fail(done));
@@ -328,7 +328,7 @@ suite('Connection close', function () {
       },
       function (send, wait, done) {
         happy_open(send, wait)
-          .then(function (f) {
+          .then(function (_f) {
             send(defs.ConnectionClose, {
               replyText: 'Begone',
               replyCode: defs.constants.INTERNAL_ERROR,
@@ -352,7 +352,7 @@ suite('Connection close', function () {
       },
       function (send, wait, done) {
         happy_open(send, wait)
-          .then(function (f) {
+          .then(function (_f) {
             send(defs.ConnectionClose, {
               replyText: 'Begone',
               replyCode: defs.constants.CONNECTION_FORCED,
@@ -445,7 +445,7 @@ suite('heartbeats', function () {
         c.on('error', succeed(done));
         c.open(opts);
       },
-      function (send, wait, done, socket) {
+      function (send, wait, done, _socket) {
         happy_open(send, wait).then(succeed(done), fail(done));
         // conspicuously not sending anything ...
       },

--- a/test/frame.js
+++ b/test/frame.js
@@ -55,7 +55,7 @@ suite('Explicit parsing', function () {
       var frames = new Frames(input);
       frames.frameMax = 5; //for the max frame test
       input.write(Buffer.from(bytes));
-      frames.step(function (err, frame) {
+      frames.step(function (err, _frame) {
         if (err != null) done();
         else done(new Error('Was a bogus frame!'));
       });


### PR DESCRIPTION
- Enable noUnusedFunctionParameters Biome lint rule as error
- Prefix unused parameters with underscore throughout codebase
- Update package.json to increase lint diagnostics limit
- Exclude generated lib/defs.js from Biome linting
- Add project-specific linting guidelines to CLAUDE.md

🤖 Generated with [Claude Code](https://claude.ai/code)