### PR TITLE
Modernisation 5 - Replace all var declarations with let/const for modern JavaScript sta…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add npm format script for manual code formatting
 - Enable noUnusedFunctionParameters lint rule and fix all violations
 - Enable noUnusedVariables lint rule and remove all unused variables from codebase
+- Replace all var declarations with let/const for modern JavaScript standards
 
 ## v0.10.9
 - Add support for IPv6 urls

--- a/bin/generate-defs.js
+++ b/bin/generate-defs.js
@@ -1,16 +1,16 @@
-var format = require('util').format;
+const format = require('util').format;
 
-var defs = require('./amqp-rabbitmq-0.9.1.json');
+const defs = require('./amqp-rabbitmq-0.9.1.json');
 
-var FRAME_OVERHEAD = 8; // type + channel + size + frame-end
+const FRAME_OVERHEAD = 8; // type + channel + size + frame-end
 
-var METHOD_OVERHEAD = FRAME_OVERHEAD + 4;
+const METHOD_OVERHEAD = FRAME_OVERHEAD + 4;
 // F_O + classId + methodId
 
-var PROPERTIES_OVERHEAD = FRAME_OVERHEAD + 4 + 8 + 2;
+const PROPERTIES_OVERHEAD = FRAME_OVERHEAD + 4 + 8 + 2;
 // F_O + classId + weight + content size + flags
 
-var out = process.stdout;
+const out = process.stdout;
 
 function printf() {
   out.write(format.apply(format, arguments), 'utf8');
@@ -24,11 +24,11 @@ function println() {
   nl();
 }
 
-var constants = {};
-var constant_strs = {};
+const constants = {};
+const constant_strs = {};
 
-for (var i = 0, len = defs.constants.length; i < len; i++) {
-  var cdef = defs.constants[i];
+for (let i = 0, len = defs.constants.length; i < len; i++) {
+  const cdef = defs.constants[i];
   constants[constantName(cdef)] = cdef.value;
   constant_strs[cdef.value] = cdef.name;
 }
@@ -42,7 +42,7 @@ function methodName(clazz, method) {
 }
 
 function propertyName(dashed) {
-  var parts = dashed.split('-');
+  const parts = dashed.split('-');
   return parts[0] + parts.slice(1).map(initial).join('');
 }
 
@@ -51,26 +51,26 @@ function initial(part) {
 }
 
 function argument(a) {
-  var type = a.type || domains[a.domain];
-  var friendlyName = propertyName(a.name);
+  const type = a.type || domains[a.domain];
+  const friendlyName = propertyName(a.name);
   return {type: type, name: friendlyName, default: a['default-value']};
 }
 
-var domains = {};
-for (var i = 0, len = defs.domains.length; i < len; i++) {
-  var dom = defs.domains[i];
+const domains = {};
+for (let i = 0, len = defs.domains.length; i < len; i++) {
+  const dom = defs.domains[i];
   domains[dom[0]] = dom[1];
 }
 
-var methods = {};
-var propertieses = {};
+const methods = {};
+const propertieses = {};
 
-for (var i = 0, len = defs.classes.length; i < len; i++) {
-  var clazz = defs.classes[i];
-  for (var j = 0, num = clazz.methods.length; j < num; j++) {
-    var method = clazz.methods[j];
-    var name = methodName(clazz, method);
-    var info = 'methodInfo' + name;
+for (let i = 0, len = defs.classes.length; i < len; i++) {
+  const clazz = defs.classes[i];
+  for (let j = 0, num = clazz.methods.length; j < num; j++) {
+    const method = clazz.methods[j];
+    const name = methodName(clazz, method);
+    const info = 'methodInfo' + name;
 
     methods[name] = {
       id: methodId(clazz, method),
@@ -86,8 +86,8 @@ for (var i = 0, len = defs.classes.length; i < len; i++) {
     };
   }
   if (clazz.properties && clazz.properties.length > 0) {
-    var name = propertiesName(clazz);
-    var props = clazz.properties;
+    const name = propertiesName(clazz);
+    const props = clazz.properties;
     propertieses[name] = {
       id: clazz.id,
       name: name,
@@ -130,12 +130,12 @@ nl();
 
 println('module.exports.decode = function(id, buf) {');
 println('switch (id) {');
-for (var m in methods) {
-  var method = methods[m];
+for (const m in methods) {
+  const method = methods[m];
   println('case %d: return %s(buf);', method.id, method.decoder);
 }
-for (var p in propertieses) {
-  var props = propertieses[p];
+for (const p in propertieses) {
+  const props = propertieses[p];
   println('case %d: return %s(buf);', props.id, props.decoder);
 }
 println('default: throw new Error("Unknown class/method ID");');
@@ -144,8 +144,8 @@ nl();
 
 println('module.exports.encodeMethod =', 'function(id, channel, fields) {');
 println('switch (id) {');
-for (var m in methods) {
-  var method = methods[m];
+for (const m in methods) {
+  const method = methods[m];
   println('case %d: return %s(channel, fields);', method.id, method.encoder);
 }
 println('default: throw new Error("Unknown class/method ID");');
@@ -154,8 +154,8 @@ nl();
 
 println('module.exports.encodeProperties =', 'function(id, channel, size, fields) {');
 println('switch (id) {');
-for (var p in propertieses) {
-  var props = propertieses[p];
+for (const p in propertieses) {
+  const props = propertieses[p];
   println('case %d: return %s(channel, size, fields);', props.id, props.encoder);
 }
 println('default: throw new Error("Unknown class/properties ID");');
@@ -164,20 +164,20 @@ nl();
 
 println('module.exports.info = function(id) {');
 println('switch(id) {');
-for (var m in methods) {
-  var method = methods[m];
+for (const m in methods) {
+  const method = methods[m];
   println('case %d: return %s; ', method.id, method.info);
 }
-for (var p in propertieses) {
-  var properties = propertieses[p];
+for (const p in propertieses) {
+  const properties = propertieses[p];
   println('case %d: return %s', properties.id, properties.info);
 }
 println('default: throw new Error("Unknown class/method ID");');
 println('}}');
 nl();
 
-for (var m in methods) {
-  var method = methods[m];
+for (const m in methods) {
+  const method = methods[m];
   println('module.exports.%s = %d;', m, method.id);
   decoderFn(method);
   nl();
@@ -187,8 +187,8 @@ for (var m in methods) {
   nl();
 }
 
-for (var p in propertieses) {
-  var properties = propertieses[p];
+for (const p in propertieses) {
+  const properties = propertieses[p];
   println('module.exports.%s = %d;', p, properties.id);
   encodePropsFn(properties);
   nl();
@@ -291,7 +291,7 @@ function checkAssignArg(a) {
 // another buffer before returning. `scratchOffset`, `val`, `len` are
 // expected to have been declared.
 function assignTable(a) {
-  var varname = tableVar(a);
+  const varname = tableVar(a);
   println('len = encodeTable(SCRATCH, val, scratchOffset);');
   println('var %s = SCRATCH.slice(scratchOffset, scratchOffset + len);', varname);
   println('scratchOffset += len;');
@@ -306,13 +306,13 @@ function stringLenVar(a) {
 }
 
 function assignStringLen(a) {
-  var v = stringLenVar(a);
+  const v = stringLenVar(a);
   // Assumes the value or default is in val
   println("var %s = Buffer.byteLength(val, 'utf8');", v);
 }
 
 function encoderFn(method) {
-  var args = method['args'];
+  const args = method['args'];
   println('function %s(channel, fields) {', method.encoder);
   println('var offset = 0, val = null, bits = 0, varyingSize = 0;');
   println('var len, scratchOffset = 0;');
@@ -323,12 +323,12 @@ function encoderFn(method) {
   // either 1. contribute to the fixed size; or 2. emit code to
   // calculate the size (and possibly the encoded value, in the case
   // of tables).
-  var fixedSize = METHOD_OVERHEAD;
+  let fixedSize = METHOD_OVERHEAD;
 
-  var bitsInARow = 0;
+  let bitsInARow = 0;
 
-  for (var i = 0, len = args.length; i < len; i++) {
-    var arg = args[i];
+  for (let i = 0, len = args.length; i < len; i++) {
+    const arg = args[i];
 
     if (arg.type != 'bit') bitsInARow = 0;
 
@@ -387,8 +387,8 @@ function encoderFn(method) {
 
   bitsInARow = 0;
 
-  for (var i = 0, len = args.length; i < len; i++) {
-    var a = args[i];
+  for (let i = 0, len = args.length; i < len; i++) {
+    const a = args[i];
 
     // Flush any collected bits before doing a new field
     if (a.type != 'bit' && bitsInARow > 0) {
@@ -457,23 +457,23 @@ function encoderFn(method) {
 
 function fieldsDecl(args) {
   println('var fields = {');
-  for (var i = 0, num = args.length; i < num; i++) {
+  for (let i = 0, num = args.length; i < num; i++) {
     println('%s: undefined,', args[i].name);
   }
   println('};');
 }
 
 function decoderFn(method) {
-  var args = method.args;
+  const args = method.args;
   println('function %s(buffer) {', method.decoder);
   println('var offset = 0, val, len;');
   fieldsDecl(args);
 
-  var bitsInARow = 0;
+  let bitsInARow = 0;
 
-  for (var i = 0, num = args.length; i < num; i++) {
-    var a = args[i];
-    var field = "fields['" + a.name + "']";
+  for (let i = 0, num = args.length; i < num; i++) {
+    const a = args[i];
+    const field = "fields['" + a.name + "']";
 
     // Flush any collected bits before doing a new field
     if (a.type != 'bit' && bitsInARow > 0) {
@@ -496,7 +496,7 @@ function decoderFn(method) {
         println('val = ints.readUInt64BE(buffer, offset); offset += 8;');
         break;
       case 'bit':
-        var bit = 1 << bitsInARow;
+        const bit = 1 << bitsInARow;
         println('val = !!(buffer[offset] & %d);', bit);
         if (bitsInARow === 7) {
           println('offset++;');
@@ -528,7 +528,7 @@ function decoderFn(method) {
 }
 
 function infoObj(thing) {
-  var info = JSON.stringify({id: thing.id, classId: thing.clazzId, methodId: thing.methodId, name: thing.name, args: thing.args});
+  const info = JSON.stringify({id: thing.id, classId: thing.clazzId, methodId: thing.methodId, name: thing.name, args: thing.args});
   println('var %s = module.exports.%s = %s;', thing.info, thing.info, info);
 }
 
@@ -551,16 +551,16 @@ function encodePropsFn(props) {
   println('var offset = 0, flags = 0, val, len;');
   println('var scratchOffset = 0, varyingSize = 0;');
 
-  var fixedSize = PROPERTIES_OVERHEAD;
+  const fixedSize = PROPERTIES_OVERHEAD;
 
-  var args = props.args;
+  const args = props.args;
 
   function incVarying(by) {
     println('varyingSize += %d;', by);
   }
 
-  for (var i = 0, num = args.length; i < num; i++) {
-    var p = args[i];
+  for (let i = 0, num = args.length; i < num; i++) {
+    const p = args[i];
 
     assignArg(p);
     println('if (val != undefined) {');
@@ -617,9 +617,9 @@ function encodePropsFn(props) {
   // we'll write the flags later too
   println('offset = 21;');
 
-  for (var i = 0, num = args.length; i < num; i++) {
-    var p = args[i];
-    var flag = flagAt(i);
+  for (let i = 0, num = args.length; i < num; i++) {
+    const p = args[i];
+    const flag = flagAt(i);
 
     assignArg(p);
     println('if (val != undefined) {');
@@ -645,7 +645,7 @@ function encodePropsFn(props) {
           println('offset += 8;');
           break;
         case 'shortstr':
-          var v = stringLenVar(p);
+          const v = stringLenVar(p);
           println('buffer[offset] = %s; offset++;', v);
           println("buffer.write(val, offset, 'utf8');");
           println('offset += %s;', v);
@@ -674,7 +674,7 @@ function encodePropsFn(props) {
 }
 
 function decodePropsFn(props) {
-  var args = props.args;
+  const args = props.args;
 
   println('function %s(buffer) {', props.decoder);
   println('var flags, offset = 2, val, len;');
@@ -684,9 +684,9 @@ function decodePropsFn(props) {
 
   fieldsDecl(args);
 
-  for (var i = 0, num = args.length; i < num; i++) {
-    var p = argument(args[i]);
-    var field = "fields['" + p.name + "']";
+  for (let i = 0, num = args.length; i < num; i++) {
+    const p = argument(args[i]);
+    const field = "fields['" + p.name + "']";
 
     println('if (flags & %d) {', flagAt(i));
     if (p.type === 'bit') {

--- a/biome.json
+++ b/biome.json
@@ -42,7 +42,8 @@
         "noGlobalIsNan": "off",
         "noRedeclare": "off",
         "noGlobalIsFinite": "off",
-        "noPrototypeBuiltins": "off"
+        "noPrototypeBuiltins": "off",
+        "noVar": "error"
       }
     }
   },

--- a/biome.json
+++ b/biome.json
@@ -25,7 +25,7 @@
         "noInnerDeclarations": "error",
         "useParseIntRadix": "off",
         "noSwitchDeclarations": "off",
-        "noInvalidUseBeforeDeclaration": "off",
+        "noInvalidUseBeforeDeclaration": "error",
         "noPrecisionLoss": "off"
       },
       "style": {

--- a/biome.json
+++ b/biome.json
@@ -22,7 +22,7 @@
       "correctness": {
         "noUnusedFunctionParameters": "error",
         "noUnusedVariables": "error",
-        "noInnerDeclarations": "off",
+        "noInnerDeclarations": "error",
         "useParseIntRadix": "off",
         "noSwitchDeclarations": "off",
         "noInvalidUseBeforeDeclaration": "off",

--- a/callback_api.js
+++ b/callback_api.js
@@ -1,5 +1,5 @@
-var raw_connect = require('./lib/connect').connect;
-var CallbackModel = require('./lib/callback_model').CallbackModel;
+const raw_connect = require('./lib/connect').connect;
+const CallbackModel = require('./lib/callback_model').CallbackModel;
 
 // Supports three shapes:
 // connect(url, options, callback)

--- a/channel_api.js
+++ b/channel_api.js
@@ -1,6 +1,6 @@
-var raw_connect = require('./lib/connect').connect;
-var ChannelModel = require('./lib/channel_model').ChannelModel;
-var promisify = require('util').promisify;
+const raw_connect = require('./lib/connect').connect;
+const ChannelModel = require('./lib/channel_model').ChannelModel;
+const promisify = require('util').promisify;
 
 function connect(url, connOptions) {
   return promisify(function (cb) {

--- a/examples/waitForConfirms.js
+++ b/examples/waitForConfirms.js
@@ -6,7 +6,7 @@ const amqp = require('../');
     connection = await amqp.connect();
     const channel = await connection.createConfirmChannel();
 
-    for (var i = 0; i < 20; i++) {
+    for (let i = 0; i < 20; i++) {
       channel.publish('amq.topic', 'whatever', Buffer.from('blah'));
     }
 

--- a/lib/api_args.js
+++ b/lib/api_args.js
@@ -41,15 +41,15 @@ function setIfDefined(obj, prop, value) {
   if (value != undefined) obj[prop] = value;
 }
 
-var EMPTY_OPTIONS = Object.freeze({});
+const EMPTY_OPTIONS = Object.freeze({});
 
-var Args = {};
+const Args = {};
 
 Args.assertQueue = function (queue, options) {
   queue = queue || '';
   options = options || EMPTY_OPTIONS;
 
-  var argt = Object.create(options.arguments || null);
+  const argt = Object.create(options.arguments || null);
   setIfDefined(argt, 'x-expires', options.expires);
   setIfDefined(argt, 'x-message-ttl', options.messageTtl);
   setIfDefined(argt, 'x-dead-letter-exchange', options.deadLetterExchange);
@@ -127,7 +127,7 @@ Args.unbindQueue = function (queue, source, pattern, argt) {
 
 Args.assertExchange = function (exchange, type, options) {
   options = options || EMPTY_OPTIONS;
-  var argt = Object.create(options.arguments || null);
+  const argt = Object.create(options.arguments || null);
   setIfDefined(argt, 'alternate-exchange', options.alternateExchange);
   return {
     exchange: exchange,
@@ -208,11 +208,11 @@ Args.publish = function (exchange, routingKey, options) {
     } else return [String(cc)];
   }
 
-  var headers = Object.create(options.headers || null);
+  const headers = Object.create(options.headers || null);
   setIfDefined(headers, 'CC', convertCC(options.CC));
   setIfDefined(headers, 'BCC', convertCC(options.BCC));
 
-  var deliveryMode; // undefined will default to 1 (non-persistent)
+  let deliveryMode; // undefined will default to 1 (non-persistent)
 
   // Previously I overloaded deliveryMode be a boolean meaning
   // 'persistent or not'; better is to name this option for what it
@@ -224,7 +224,7 @@ Args.publish = function (exchange, routingKey, options) {
     // is supplied and truthy
     deliveryMode = 2;
 
-  var expiration = options.expiration;
+  let expiration = options.expiration;
   if (expiration !== undefined) expiration = expiration.toString();
 
   return {
@@ -254,7 +254,7 @@ Args.publish = function (exchange, routingKey, options) {
 
 Args.consume = function (queue, options) {
   options = options || EMPTY_OPTIONS;
-  var argt = Object.create(options.arguments || null);
+  const argt = Object.create(options.arguments || null);
   setIfDefined(argt, 'x-priority', options.priority);
   return {
     ticket: 0,

--- a/lib/callback_model.js
+++ b/lib/callback_model.js
@@ -4,17 +4,17 @@
 
 'use strict';
 
-var defs = require('./defs');
-var EventEmitter = require('events');
-var BaseChannel = require('./channel').BaseChannel;
-var acceptMessage = require('./channel').acceptMessage;
-var Args = require('./api_args');
+const defs = require('./defs');
+const EventEmitter = require('events');
+const BaseChannel = require('./channel').BaseChannel;
+const acceptMessage = require('./channel').acceptMessage;
+const Args = require('./api_args');
 
 class CallbackModel extends EventEmitter {
   constructor(connection) {
     super();
     this.connection = connection;
-    var self = this;
+    const self = this;
     ['error', 'close', 'blocked', 'unblocked'].forEach(function (ev) {
       connection.on(ev, self.emit.bind(self, ev));
     });
@@ -33,7 +33,7 @@ class CallbackModel extends EventEmitter {
       cb = options;
       options = undefined;
     }
-    var ch = new Channel(this.connection);
+    const ch = new Channel(this.connection);
     ch.setOptions(options);
     ch.open(function (err, _ok) {
       if (err === null) cb && cb(null, ch);
@@ -47,7 +47,7 @@ class CallbackModel extends EventEmitter {
       cb = options;
       options = undefined;
     }
-    var ch = new ConfirmChannel(this.connection);
+    const ch = new ConfirmChannel(this.connection);
     ch.setOptions(options);
     ch.open(function (err) {
       if (err !== null) return cb && cb(err);
@@ -76,7 +76,7 @@ class Channel extends BaseChannel {
   // use `#_rpc(...)` and remember to dereference `.fields` of the
   // server response.
   rpc(method, fields, expect, cb0) {
-    var cb = callbackWrapper(this, cb0);
+    const cb = callbackWrapper(this, cb0);
     this._rpc(method, fields, expect, function (err, ok) {
       cb(err, ok && ok.fields); // in case of an error, ok will be
 
@@ -127,7 +127,7 @@ class Channel extends BaseChannel {
   }
 
   assertExchange(ex, type, options, cb0) {
-    var cb = callbackWrapper(this, cb0);
+    const cb = callbackWrapper(this, cb0);
     this._rpc(defs.ExchangeDeclare, Args.assertExchange(ex, type, options), defs.ExchangeDeclareOk, function (e, _) {
       cb(e, {exchange: ex});
     });
@@ -151,7 +151,7 @@ class Channel extends BaseChannel {
   }
 
   publish(exchange, routingKey, content, options) {
-    var fieldsAndProps = Args.publish(exchange, routingKey, options);
+    const fieldsAndProps = Args.publish(exchange, routingKey, options);
     return this.sendMessage(fieldsAndProps, fieldsAndProps, content);
   }
 
@@ -160,9 +160,9 @@ class Channel extends BaseChannel {
   }
 
   consume(queue, callback, options, cb0) {
-    var cb = callbackWrapper(this, cb0);
-    var fields = Args.consume(queue, options);
-    var self = this;
+    const cb = callbackWrapper(this, cb0);
+    const fields = Args.consume(queue, options);
+    const self = this;
     this._rpc(defs.BasicConsume, fields, defs.BasicConsumeOk, function (err, ok) {
       if (err === null) {
         self.registerConsumer(ok.fields.consumerTag, callback);
@@ -173,8 +173,8 @@ class Channel extends BaseChannel {
   }
 
   cancel(consumerTag, cb0) {
-    var cb = callbackWrapper(this, cb0);
-    var self = this;
+    const cb = callbackWrapper(this, cb0);
+    const self = this;
     this._rpc(defs.BasicCancel, Args.cancel(consumerTag), defs.BasicCancelOk, function (err, ok) {
       if (err === null) {
         self.unregisterConsumer(consumerTag);
@@ -185,9 +185,9 @@ class Channel extends BaseChannel {
   }
 
   get(queue, options, cb0) {
-    var self = this;
-    var fields = Args.get(queue, options);
-    var cb = callbackWrapper(this, cb0);
+    const self = this;
+    const fields = Args.get(queue, options);
+    const cb = callbackWrapper(this, cb0);
     this.sendOrEnqueue(defs.BasicGet, fields, function (err, f) {
       if (err === null) {
         if (f.id === defs.BasicGetEmpty) {
@@ -265,12 +265,12 @@ class ConfirmChannel extends Channel {
   }
 
   waitForConfirms(k) {
-    var awaiting = [];
-    var unconfirmed = this.unconfirmed;
+    const awaiting = [];
+    const unconfirmed = this.unconfirmed;
     unconfirmed.forEach(function (val, index) {
       if (val === null); // already confirmed
       else {
-        var confirmed = new Promise(function (resolve, reject) {
+        const confirmed = new Promise(function (resolve, reject) {
           unconfirmed[index] = function (err) {
             if (val) val(err);
             if (err === null) resolve();

--- a/lib/channel.js
+++ b/lib/channel.js
@@ -6,15 +6,15 @@
 
 'use strict';
 
-var defs = require('./defs');
-var closeMsg = require('./format').closeMessage;
-var inspect = require('./format').inspect;
-var methodName = require('./format').methodName;
-var assert = require('assert');
-var EventEmitter = require('events');
-var fmt = require('util').format;
-var IllegalOperationError = require('./error').IllegalOperationError;
-var stackCapture = require('./error').stackCapture;
+const defs = require('./defs');
+const closeMsg = require('./format').closeMessage;
+const inspect = require('./format').inspect;
+const methodName = require('./format').methodName;
+const assert = require('assert');
+const EventEmitter = require('events');
+const fmt = require('util').format;
+const IllegalOperationError = require('./error').IllegalOperationError;
+const stackCapture = require('./error').stackCapture;
 
 class Channel extends EventEmitter {
   constructor(connection) {
@@ -41,7 +41,7 @@ class Channel extends EventEmitter {
       }),
     );
     this.on('close', function () {
-      var cb;
+      let cb;
       while ((cb = this.unconfirmed.shift())) {
         if (cb) cb(new Error('channel closed'));
       }
@@ -100,7 +100,7 @@ class Channel extends EventEmitter {
   // Internal, synchronously resolved RPC; the return value is resolved
   // with the whole frame.
   _rpc(method, fields, expect, cb) {
-    var self = this;
+    const self = this;
 
     function reply(err, f) {
       if (err === null) {
@@ -109,9 +109,9 @@ class Channel extends EventEmitter {
         } else {
           // We have detected a problem, so it's up to us to close the
           // channel
-          var expectedName = methodName(expect);
+          const expectedName = methodName(expect);
 
-          var e = new Error(fmt('Expected %s; got %s', expectedName, inspect(f, false)));
+          const e = new Error(fmt('Expected %s; got %s', expectedName, inspect(f, false)));
           self.closeWithError(f.id, fmt('Expected %s; got %s', expectedName, methodName(f.id)), defs.constants.UNEXPECTED_FRAME, e);
           return cb(e);
         }
@@ -124,12 +124,12 @@ class Channel extends EventEmitter {
       // and the channel is closed by the server
       else {
         // otherwise, it's a close frame
-        var closeReason = (err.fields.classId << 16) + err.fields.methodId;
-        var e =
+        const closeReason = (err.fields.classId << 16) + err.fields.methodId;
+        const e =
           method === closeReason
             ? fmt('Operation failed: %s; %s', methodName(method), closeMsg(err))
             : fmt('Channel closed by server: %s', closeMsg(err));
-        var closeFrameError = new Error(e);
+        const closeFrameError = new Error(e);
         closeFrameError.code = err.fields.replyCode;
         closeFrameError.classId = err.fields.classId;
         closeFrameError.methodId = err.fields.methodId;
@@ -154,13 +154,13 @@ class Channel extends EventEmitter {
   // acknowledged the close, but before the channel is moved to the
   // closed state.
   toClosing(capturedStack, k) {
-    var send = this.sendImmediately.bind(this);
+    const send = this.sendImmediately.bind(this);
     invalidateSend(this, 'Channel closing', capturedStack);
 
     this.accept = function (f) {
       if (f.id === defs.ChannelCloseOk) {
         if (k) k();
-        var s = stackCapture('ChannelCloseOk frame received');
+        const s = stackCapture('ChannelCloseOk frame received');
         this.toClosed(s);
       } else if (f.id === defs.ChannelClose) {
         send(defs.ChannelCloseOk, {});
@@ -176,7 +176,7 @@ class Channel extends EventEmitter {
     if (this.reply !== null) rej(this.reply);
     this.reply = null;
 
-    var discard;
+    let discard;
     while ((discard = this.pending.shift())) rej(discard.reply);
     this.pending = null; // so pushes will break
   }
@@ -188,7 +188,7 @@ class Channel extends EventEmitter {
       methodId: 0,
       classId: 0,
     });
-    var s = stackCapture('closeBecause called: ' + reason);
+    const s = stackCapture('closeBecause called: ' + reason);
     this.toClosing(s, k);
   }
 
@@ -196,7 +196,7 @@ class Channel extends EventEmitter {
   // between what we tell the server (`reason`) and what we report as
   // the cause in the client (`error`).
   closeWithError(id, reason, code, error) {
-    var self = this;
+    const self = this;
     this.closeBecause(reason, code, function () {
       error.code = code;
       // content frames and consumer errors do not provide a method a class/method ID
@@ -230,15 +230,15 @@ class Channel extends EventEmitter {
   }
 
   handleConfirm(handle, f) {
-    var tag = f.deliveryTag;
-    var multi = f.multiple;
+    const tag = f.deliveryTag;
+    const multi = f.multiple;
 
     if (multi) {
-      var confirmed = this.unconfirmed.splice(0, tag - this.lwm + 1);
+      const confirmed = this.unconfirmed.splice(0, tag - this.lwm + 1);
       this.lwm = tag + 1;
       confirmed.forEach(handle);
     } else {
-      var c;
+      let c;
       if (tag === this.lwm) {
         c = this.unconfirmed.shift();
         this.lwm++;
@@ -292,20 +292,20 @@ class Channel extends EventEmitter {
         // with the close frame, so it can see whether it was that
         // operation that caused it to close.
         if (this.reply) {
-          var reply = this.reply;
+          const reply = this.reply;
           this.reply = null;
           reply(f);
         }
-        var emsg = 'Channel closed by server: ' + closeMsg(f);
+        const emsg = 'Channel closed by server: ' + closeMsg(f);
         this.sendImmediately(defs.ChannelCloseOk, {});
 
-        var error = new Error(emsg);
+        const error = new Error(emsg);
         error.code = f.fields.replyCode;
         error.classId = f.fields.classId;
         error.methodId = f.fields.methodId;
         this.emit('error', error);
 
-        var s = stackCapture(emsg);
+        const s = stackCapture(emsg);
         this.toClosed(s);
         return;
 
@@ -316,14 +316,14 @@ class Channel extends EventEmitter {
       default: // assume all other things are replies
         // Resolving the reply may lead to another RPC; to make sure we
         // don't hold that up, clear this.reply
-        var reply = this.reply;
+        const reply = this.reply;
         this.reply = null;
         // however, maybe there's an RPC waiting to go? If so, that'll
         // fill this.reply again, restoring the invariant. This does rely
         // on any response being recv'ed after resolving the promise,
         // below; hence, I use synchronous defer.
         if (this.pending.length > 0) {
-          var send = this.pending.shift();
+          const send = this.pending.shift();
           this.reply = send.reply;
           this.sendImmediately(send.method, send.fields);
         }
@@ -358,13 +358,13 @@ function invalidateSend(ch, msg, stack) {
 // Kick off a message delivery given a BasicDeliver or BasicReturn
 // frame (BasicGet uses the RPC mechanism)
 function acceptDeliveryOrReturn(f) {
-  var event;
+  let event;
   if (f.id === defs.BasicDeliver) event = 'delivery';
   else if (f.id === defs.BasicReturn) event = 'return';
   else throw fmt('Expected BasicDeliver or BasicReturn; got %s', inspect(f));
 
-  var self = this;
-  var fields = f.fields;
+  const self = this;
+  const fields = f.fields;
   return acceptMessage(function (message) {
     message.fields = fields;
     self.emit(event, message);
@@ -374,11 +374,11 @@ function acceptDeliveryOrReturn(f) {
 // Move to the state of waiting for message frames (headers, then
 // one or more content frames)
 function acceptMessage(continuation) {
-  var totalSize = 0,
+  let totalSize = 0,
     remaining = 0;
-  var buffers = null;
+  let buffers = null;
 
-  var message = {
+  const message = {
     fields: null,
     properties: null,
     content: null,
@@ -409,7 +409,7 @@ function acceptMessage(continuation) {
   // %%% TODO cancelled messages (sent as zero-length content frame)
   function content(f) {
     if (f.content) {
-      var size = f.content.length;
+      const size = f.content.length;
       remaining -= size;
       if (remaining === 0) {
         if (buffers !== null) {
@@ -450,8 +450,8 @@ class BaseChannel extends Channel {
   }
 
   dispatchMessage(fields, message) {
-    var consumerTag = fields.consumerTag;
-    var consumer = this.consumers.get(consumerTag);
+    const consumerTag = fields.consumerTag;
+    const consumer = this.consumers.get(consumerTag);
     if (consumer) {
       return consumer(message);
     } else {
@@ -465,7 +465,7 @@ class BaseChannel extends Channel {
   }
 
   handleCancel(fields) {
-    var result = this.dispatchMessage(fields, null);
+    const result = this.dispatchMessage(fields, null);
     this.unregisterConsumer(fields.consumerTag);
     return result;
   }

--- a/lib/channel_model.js
+++ b/lib/channel_model.js
@@ -255,7 +255,7 @@ class ConfirmChannel extends Channel {
     });
     // Channel closed
     if (!this.pending) {
-      var cb;
+      let cb;
       while ((cb = this.unconfirmed.shift())) {
         if (cb) cb(new Error('channel closed'));
       }

--- a/lib/codec.js
+++ b/lib/codec.js
@@ -53,7 +53,7 @@ properties are present. This scheme can save ones of bytes per message
 
 'use strict';
 
-var ints = require('buffer-more-ints');
+const ints = require('buffer-more-ints');
 
 // JavaScript uses only doubles so what I'm testing for is whether
 // it's *better* to encode a number as a float or double. This really
@@ -73,11 +73,11 @@ function isFloatingPoint(n) {
 }
 
 function encodeTable(buffer, val, offset) {
-  var start = offset;
+  const start = offset;
   offset += 4; // leave room for the table length
-  for (var key in val) {
+  for (const key in val) {
     if (val[key] !== undefined) {
-      var len = Buffer.byteLength(key);
+      const len = Buffer.byteLength(key);
       buffer.writeUInt8(len, offset);
       offset++;
       buffer.write(key, offset, 'utf8');
@@ -85,25 +85,25 @@ function encodeTable(buffer, val, offset) {
       offset += encodeFieldValue(buffer, val[key], offset);
     }
   }
-  var size = offset - start;
+  const size = offset - start;
   buffer.writeUInt32BE(size - 4, start);
   return size;
 }
 
 function encodeArray(buffer, val, offset) {
-  var start = offset;
+  const start = offset;
   offset += 4;
-  for (var i = 0, num = val.length; i < num; i++) {
+  for (let i = 0, num = val.length; i < num; i++) {
     offset += encodeFieldValue(buffer, val[i], offset);
   }
-  var size = offset - start;
+  const size = offset - start;
   buffer.writeUInt32BE(size - 4, start);
   return size;
 }
 
 function encodeFieldValue(buffer, value, offset) {
-  var start = offset;
-  var type = typeof value,
+  const start = offset;
+  let type = typeof value,
     val = value;
   // A trapdoor for specifying a type, e.g., timestamp
   if (value && type === 'object' && value.hasOwnProperty('!')) {
@@ -149,7 +149,7 @@ function encodeFieldValue(buffer, value, offset) {
 
   switch (type) {
     case 'string': // no shortstr in field tables
-      var len = Buffer.byteLength(val, 'utf8');
+      const len = Buffer.byteLength(val, 'utf8');
       tag('S');
       buffer.writeUInt32BE(len, offset);
       offset += 4;
@@ -259,13 +259,13 @@ function encodeFieldValue(buffer, value, offset) {
 // Assume we're given a slice of the buffer that contains just the
 // fields.
 function decodeFields(slice) {
-  var fields = {},
+  let fields = {},
     offset = 0,
     size = slice.length;
-  var len, key, val;
+  let len, key, val;
 
   function decodeFieldValue() {
-    var tag = String.fromCharCode(slice[offset]);
+    const tag = String.fromCharCode(slice[offset]);
     offset++;
     switch (tag) {
       case 'b':
@@ -291,9 +291,9 @@ function decodeFields(slice) {
         offset += 4;
         break;
       case 'D': // only positive decimals, apparently.
-        var places = slice[offset];
+        const places = slice[offset];
         offset++;
-        var digits = slice.readUInt32BE(offset);
+        const digits = slice.readUInt32BE(offset);
         offset += 4;
         val = {'!': 'decimal', value: {places: places, digits: digits}};
         break;
@@ -353,7 +353,7 @@ function decodeFields(slice) {
   }
 
   function decodeArray(until) {
-    var vals = [];
+    const vals = [];
     while (offset < until) {
       decodeFieldValue();
       vals.push(val);

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -6,17 +6,17 @@
 
 'use strict';
 
-var URL = require('url-parse');
-var QS = require('querystring');
-var Connection = require('./connection').Connection;
-var fmt = require('util').format;
-var credentials = require('./credentials');
+const URL = require('url-parse');
+const QS = require('querystring');
+const Connection = require('./connection').Connection;
+const fmt = require('util').format;
+const credentials = require('./credentials');
 
 function copyInto(obj, target) {
-  var keys = Object.keys(obj);
-  var i = keys.length;
+  const keys = Object.keys(obj);
+  let i = keys.length;
   while (i--) {
-    var k = keys[i];
+    const k = keys[i];
     target[k] = obj[k];
   }
   return target;
@@ -27,7 +27,7 @@ function clone(obj) {
   return copyInto(obj, {});
 }
 
-var CLIENT_PROPERTIES = {
+const CLIENT_PROPERTIES = {
   product: 'amqplib',
   version: require('../package.json').version,
   platform: fmt('Node.JS %s', process.version),
@@ -53,7 +53,7 @@ function openFrames(vhost, query, credentials, extraClientProperties) {
     return val === undefined ? def : parseInt(val);
   }
 
-  var clientProperties = Object.create(CLIENT_PROPERTIES);
+  const clientProperties = Object.create(CLIENT_PROPERTIES);
 
   return {
     // start-ok
@@ -76,7 +76,7 @@ function openFrames(vhost, query, credentials, extraClientProperties) {
 
 // Decide on credentials based on what we're supplied.
 function credentialsFromUrl(parts) {
-  var user = 'guest',
+  let user = 'guest',
     passwd = 'guest';
   if (parts.username != '' || parts.password != '') {
     user = parts.username ? unescape(parts.username) : '';
@@ -90,25 +90,25 @@ function connect(url, socketOptions, openCallback) {
   // copies only properties mentioned in `Object.keys()`, when
   // processing the options. So I have to make copies too, rather
   // than using `Object.create()`.
-  var sockopts = clone(socketOptions || {});
+  const sockopts = clone(socketOptions || {});
   url = url || 'amqp://localhost';
 
-  var noDelay = !!sockopts.noDelay;
-  var timeout = sockopts.timeout;
-  var keepAlive = !!sockopts.keepAlive;
+  const noDelay = !!sockopts.noDelay;
+  const timeout = sockopts.timeout;
+  const keepAlive = !!sockopts.keepAlive;
   // 0 is default for node
-  var keepAliveDelay = sockopts.keepAliveDelay || 0;
+  const keepAliveDelay = sockopts.keepAliveDelay || 0;
 
-  var extraClientProperties = sockopts.clientProperties || {};
+  const extraClientProperties = sockopts.clientProperties || {};
 
-  var protocol, fields;
+  let protocol, fields;
   if (typeof url === 'object') {
     protocol = (url.protocol || 'amqp') + ':';
     sockopts.host = url.hostname;
     sockopts.servername = sockopts.servername || url.hostname;
     sockopts.port = url.port || (protocol === 'amqp:' ? 5672 : 5671);
 
-    var user, pass;
+    let user, pass;
     // Only default if both are missing, to have the same behaviour as
     // the stringly URL.
     if (url.username == undefined && url.password == undefined) {
@@ -119,7 +119,7 @@ function connect(url, socketOptions, openCallback) {
       pass = url.password || '';
     }
 
-    var config = {
+    const config = {
       locale: url.locale,
       channelMax: url.channelMax,
       frameMax: url.frameMax,
@@ -128,25 +128,25 @@ function connect(url, socketOptions, openCallback) {
 
     fields = openFrames(url.vhost, config, sockopts.credentials || credentials.plain(user, pass), extraClientProperties);
   } else {
-    var parts = URL(url, true); // yes, parse the query string
-    var host = parts.hostname.replace(/^\[|\]$/g, '');
+    const parts = URL(url, true); // yes, parse the query string
+    const host = parts.hostname.replace(/^\[|\]$/g, '');
     protocol = parts.protocol;
     sockopts.host = host;
     sockopts.servername = sockopts.servername || host;
     sockopts.port = parseInt(parts.port) || (protocol === 'amqp:' ? 5672 : 5671);
-    var vhost = parts.pathname ? parts.pathname.substr(1) : null;
+    const vhost = parts.pathname ? parts.pathname.substr(1) : null;
     fields = openFrames(vhost, parts.query, sockopts.credentials || credentialsFromUrl(parts), extraClientProperties);
   }
 
-  var sockok = false;
-  var sock;
+  let sockok = false;
+  let sock;
 
   function onConnect() {
     sockok = true;
     sock.setNoDelay(noDelay);
     if (keepAlive) sock.setKeepAlive(keepAlive, keepAliveDelay);
 
-    var c = new Connection(sock);
+    const c = new Connection(sock);
     c.open(fields, function (err, _ok) {
       // disable timeout once the connection is open, we don't want
       // it fouling things

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -4,40 +4,40 @@
 
 'use strict';
 
-var defs = require('./defs');
-var constants = defs.constants;
-var frame = require('./frame');
-var HEARTBEAT = frame.HEARTBEAT;
-var Mux = require('./mux').Mux;
+const defs = require('./defs');
+const constants = defs.constants;
+const frame = require('./frame');
+const HEARTBEAT = frame.HEARTBEAT;
+const Mux = require('./mux').Mux;
 
-var Duplex = require('stream').Duplex;
-var EventEmitter = require('events');
-var Heart = require('./heartbeat').Heart;
+const Duplex = require('stream').Duplex;
+const EventEmitter = require('events');
+const Heart = require('./heartbeat').Heart;
 
-var methodName = require('./format').methodName;
-var closeMsg = require('./format').closeMessage;
-var inspect = require('./format').inspect;
+const methodName = require('./format').methodName;
+const closeMsg = require('./format').closeMessage;
+const inspect = require('./format').inspect;
 
-var BitSet = require('./bitset').BitSet;
-var fmt = require('util').format;
-var PassThrough = require('stream').PassThrough;
-var IllegalOperationError = require('./error').IllegalOperationError;
-var stackCapture = require('./error').stackCapture;
+const BitSet = require('./bitset').BitSet;
+const fmt = require('util').format;
+const PassThrough = require('stream').PassThrough;
+const IllegalOperationError = require('./error').IllegalOperationError;
+const stackCapture = require('./error').stackCapture;
 
 // High-water mark for channel write buffers, in 'objects' (which are
 // encoded frames as buffers).
-var DEFAULT_WRITE_HWM = 1024;
+const DEFAULT_WRITE_HWM = 1024;
 // If all the frames of a message (method, properties, content) total
 // to less than this, copy them into a single buffer and write it all
 // at once. Note that this is less than the minimum frame size: if it
 // was greater, we might have to fragment the content.
-var SINGLE_CHUNK_THRESHOLD = 2048;
+const SINGLE_CHUNK_THRESHOLD = 2048;
 
 class Connection extends EventEmitter {
   constructor(underlying) {
     super();
 
-    var stream = (this.stream = wrapStream(underlying));
+    const stream = (this.stream = wrapStream(underlying));
     this.muxer = new Mux(stream);
 
     // frames
@@ -87,11 +87,11 @@ class Connection extends EventEmitter {
 
   */
   open(allFields, openCallback0) {
-    var self = this;
-    var openCallback = openCallback0 || function () {};
+    const self = this;
+    const openCallback = openCallback0 || function () {};
 
     // This is where we'll put our negotiated values
-    var tunedOptions = Object.create(allFields);
+    const tunedOptions = Object.create(allFields);
 
     function wait(k) {
       self.step(function (err, frame) {
@@ -136,7 +136,7 @@ class Connection extends EventEmitter {
     }
 
     function onStart(start) {
-      var mechanisms = start.fields.mechanisms.toString().split(' ');
+      const mechanisms = start.fields.mechanisms.toString().split(' ');
       if (mechanisms.indexOf(allFields.mechanism) < 0) {
         bail(new Error(fmt('SASL mechanism %s is not provided by the server', allFields.mechanism)));
         return;
@@ -160,7 +160,7 @@ class Connection extends EventEmitter {
           bail(new Error(fmt('Handshake terminated by server: %s', closeMsg(reply))));
           break;
         case defs.ConnectionTune:
-          var fields = reply.fields;
+          const fields = reply.fields;
           tunedOptions.frameMax = negotiate(fields.frameMax, allFields.frameMax);
           tunedOptions.channelMax = negotiate(fields.channelMax, allFields.channelMax);
           tunedOptions.heartbeat = negotiate(fields.heartbeat, allFields.heartbeat);
@@ -262,7 +262,7 @@ class Connection extends EventEmitter {
   // resolved.
   // Close the connection without even giving a reason. Typical.
   close(closeCallback) {
-    var k =
+    const k =
       closeCallback &&
       function () {
         closeCallback(null);
@@ -280,7 +280,7 @@ class Connection extends EventEmitter {
       methodId: 0,
       classId: 0,
     });
-    var s = stackCapture('closeBecause called: ' + reason);
+    const s = stackCapture('closeBecause called: ' + reason);
     this.toClosing(s, k);
   }
 
@@ -295,7 +295,7 @@ class Connection extends EventEmitter {
       // up for `'error'` *and* `'end'`
       this.expectSocketClose = true;
       this.emit('error', err);
-      var s = stackCapture('Socket error');
+      const s = stackCapture('Socket error');
       this.toClosed(s, err);
     }
   }
@@ -304,12 +304,12 @@ class Connection extends EventEmitter {
   // This means we should not send more frames, anyway they will be
   // ignored. We also have to shut down all the channels.
   toClosing(capturedStack, k) {
-    var send = this.sendMethod.bind(this);
+    const send = this.sendMethod.bind(this);
 
     this.accept = function (f) {
       if (f.id === defs.ConnectionCloseOk) {
         if (k) k();
-        var s = stackCapture('ConnectionCloseOk received');
+        const s = stackCapture('ConnectionCloseOk received');
         this.toClosed(s, undefined);
       } else if (f.id === defs.ConnectionClose) {
         send(0, defs.ConnectionCloseOk, {});
@@ -320,8 +320,8 @@ class Connection extends EventEmitter {
   }
 
   _closeChannels(capturedStack) {
-    for (var i = 1; i < this.channels.length; i++) {
-      var ch = this.channels[i];
+    for (let i = 1; i < this.channels.length; i++) {
+      const ch = this.channels[i];
       if (ch !== null) {
         ch.channel.toClosed(capturedStack); // %%% or with an error? not clear
       }
@@ -331,7 +331,7 @@ class Connection extends EventEmitter {
   // A close has been confirmed. Cease all communication.
   toClosed(capturedStack, maybeErr) {
     this._closeChannels(capturedStack);
-    var info = fmt('Connection closed (%s)', maybeErr ? maybeErr.toString() : 'by client');
+    const info = fmt('Connection closed (%s)', maybeErr ? maybeErr.toString() : 'by client');
     // Tidy up, invalidate enverything, dynamite the bridges.
     invalidateSend(this, info, capturedStack);
     this.accept = invalidOp(info, capturedStack);
@@ -357,12 +357,12 @@ class Connection extends EventEmitter {
   startHeartbeater() {
     if (this.heartbeat === 0) return null;
     else {
-      var self = this;
-      var hb = new Heart(this.heartbeat, this.checkSend.bind(this), this.checkRecv.bind(this));
+      const self = this;
+      const hb = new Heart(this.heartbeat, this.checkSend.bind(this), this.checkRecv.bind(this));
       hb.on('timeout', function () {
-        var hberr = new Error('Heartbeat timeout');
+        const hberr = new Error('Heartbeat timeout');
         self.emit('error', hberr);
-        var s = stackCapture('Heartbeat timeout');
+        const s = stackCapture('Heartbeat timeout');
         self.toClosed(s, hberr);
       });
       hb.on('beat', function () {
@@ -382,12 +382,12 @@ class Connection extends EventEmitter {
   // again rather than growing the array. See
   // http://www.html5rocks.com/en/tutorials/speed/v8/
   freshChannel(channel, options) {
-    var next = this.freeChannels.nextClearBit(1);
+    const next = this.freeChannels.nextClearBit(1);
     if (next < 0 || next > this.channelMax) throw new Error('No channels left to allocate');
     this.freeChannels.set(next);
 
-    var hwm = (options && options.highWaterMark) || DEFAULT_WRITE_HWM;
-    var writeBuffer = new PassThrough({
+    const hwm = (options && options.highWaterMark) || DEFAULT_WRITE_HWM;
+    const writeBuffer = new PassThrough({
       objectMode: true,
       highWaterMark: hwm,
     });
@@ -401,17 +401,17 @@ class Connection extends EventEmitter {
 
   releaseChannel(channel) {
     this.freeChannels.clear(channel);
-    var buffer = this.channels[channel].buffer;
+    const buffer = this.channels[channel].buffer;
     buffer.end(); // will also cause it to be unpiped
     this.channels[channel] = null;
   }
 
   acceptLoop() {
-    var self = this;
+    const self = this;
 
     function go() {
       try {
-        var f;
+        let f;
         while ((f = self.recvFrame())) self.accept(f);
       } catch (e) {
         self.emit('frameError', e);
@@ -422,9 +422,9 @@ class Connection extends EventEmitter {
   }
 
   step(cb) {
-    var self = this;
+    const self = this;
     function recv() {
-      var f;
+      let f;
       try {
         f = self.recvFrame();
       } catch (e) {
@@ -438,13 +438,13 @@ class Connection extends EventEmitter {
   }
 
   checkSend() {
-    var check = this.sentSinceLastCheck;
+    const check = this.sentSinceLastCheck;
     this.sentSinceLastCheck = false;
     return check;
   }
 
   checkRecv() {
-    var check = this.recvSinceLastCheck;
+    const check = this.recvSinceLastCheck;
     this.recvSinceLastCheck = false;
     return check;
   }
@@ -459,31 +459,31 @@ class Connection extends EventEmitter {
   }
 
   sendMethod(channel, Method, fields) {
-    var frame = encodeMethod(Method, channel, fields);
+    const frame = encodeMethod(Method, channel, fields);
     this.sentSinceLastCheck = true;
-    var buffer = this.channels[channel].buffer;
+    const buffer = this.channels[channel].buffer;
     return buffer.write(frame);
   }
 
   sendMessage(channel, Method, fields, Properties, props, content) {
     if (!Buffer.isBuffer(content)) throw new TypeError('content is not a buffer');
 
-    var mframe = encodeMethod(Method, channel, fields);
-    var pframe = encodeProperties(Properties, channel, content.length, props);
-    var buffer = this.channels[channel].buffer;
+    const mframe = encodeMethod(Method, channel, fields);
+    const pframe = encodeProperties(Properties, channel, content.length, props);
+    const buffer = this.channels[channel].buffer;
     this.sentSinceLastCheck = true;
 
-    var methodHeaderLen = mframe.length + pframe.length;
-    var bodyLen = content.length > 0 ? content.length + FRAME_OVERHEAD : 0;
-    var allLen = methodHeaderLen + bodyLen;
+    const methodHeaderLen = mframe.length + pframe.length;
+    const bodyLen = content.length > 0 ? content.length + FRAME_OVERHEAD : 0;
+    const allLen = methodHeaderLen + bodyLen;
 
     if (allLen < SINGLE_CHUNK_THRESHOLD) {
       // Use `allocUnsafe` to avoid excessive allocations and CPU usage
       // from zeroing. The returned Buffer is not zeroed and so must be
       // completely filled to be used safely.
       // See https://github.com/amqp-node/amqplib/pull/695
-      var all = Buffer.allocUnsafe(allLen);
-      var offset = mframe.copy(all, 0);
+      const all = Buffer.allocUnsafe(allLen);
+      let offset = mframe.copy(all, 0);
       offset += pframe.copy(all, offset);
 
       if (bodyLen > 0) makeBodyFrame(channel, content).copy(all, offset);
@@ -494,8 +494,8 @@ class Connection extends EventEmitter {
         // from zeroing. The returned Buffer is not zeroed and so must be
         // completely filled to be used safely.
         // See https://github.com/amqp-node/amqplib/pull/695
-        var both = Buffer.allocUnsafe(methodHeaderLen);
-        var offset = mframe.copy(both, 0);
+        const both = Buffer.allocUnsafe(methodHeaderLen);
+        const offset = mframe.copy(both, 0);
         pframe.copy(both, offset);
         buffer.write(both);
       } else {
@@ -510,15 +510,15 @@ class Connection extends EventEmitter {
     if (!Buffer.isBuffer(body)) {
       throw new TypeError(fmt('Expected buffer; got %s', body));
     }
-    var writeResult = true;
-    var buffer = this.channels[channel].buffer;
+    let writeResult = true;
+    const buffer = this.channels[channel].buffer;
 
-    var maxBody = this.frameMax - FRAME_OVERHEAD;
+    const maxBody = this.frameMax - FRAME_OVERHEAD;
 
-    for (var offset = 0; offset < body.length; offset += maxBody) {
-      var end = offset + maxBody;
-      var slice = end > body.length ? body.subarray(offset) : body.subarray(offset, end);
-      var bodyFrame = makeBodyFrame(channel, slice);
+    for (let offset = 0; offset < body.length; offset += maxBody) {
+      const end = offset + maxBody;
+      const slice = end > body.length ? body.subarray(offset) : body.subarray(offset, end);
+      const bodyFrame = makeBodyFrame(channel, slice);
       writeResult = buffer.write(bodyFrame);
     }
     this.sentSinceLastCheck = true;
@@ -527,10 +527,10 @@ class Connection extends EventEmitter {
 
   recvFrame() {
     // %%% identifying invariants might help here?
-    var frame = parseFrame(this.rest);
+    const frame = parseFrame(this.rest);
 
     if (!frame) {
-      var incoming = this.stream.read();
+      const incoming = this.stream.read();
       if (incoming === null) {
         return false;
       } else {
@@ -547,7 +547,7 @@ class Connection extends EventEmitter {
 
 // Usual frame accept mode
 function mainAccept(frame) {
-  var rec = this.channels[frame.channel];
+  const rec = this.channels[frame.channel];
   if (rec) {
     return rec.channel.accept(frame);
   }
@@ -575,9 +575,9 @@ function channel0(connection) {
     else if (f.id === defs.ConnectionClose) {
       // Oh. OK. I guess we're done here then.
       connection.sendMethod(0, defs.ConnectionCloseOk, {});
-      var emsg = fmt('Connection closed: %s', closeMsg(f));
-      var s = stackCapture(emsg);
-      var e = new Error(emsg);
+      const emsg = fmt('Connection closed: %s', closeMsg(f));
+      const s = stackCapture(emsg);
+      const e = new Error(emsg);
       e.code = f.fields.replyCode;
       if (isFatalError(e)) {
         connection.emit('error', e);
@@ -609,19 +609,19 @@ function invalidateSend(conn, msg, stack) {
   conn.sendMethod = conn.sendContent = conn.sendMessage = invalidOp(msg, stack);
 }
 
-var encodeMethod = defs.encodeMethod;
-var encodeProperties = defs.encodeProperties;
+const encodeMethod = defs.encodeMethod;
+const encodeProperties = defs.encodeProperties;
 
-var FRAME_OVERHEAD = defs.FRAME_OVERHEAD;
-var makeBodyFrame = frame.makeBodyFrame;
+const FRAME_OVERHEAD = defs.FRAME_OVERHEAD;
+const makeBodyFrame = frame.makeBodyFrame;
 
-var parseFrame = frame.parseFrame;
-var decodeFrame = frame.decodeFrame;
+const parseFrame = frame.parseFrame;
+const decodeFrame = frame.decodeFrame;
 
 function wrapStream(s) {
   if (s instanceof Duplex) return s;
   else {
-    var ws = new Duplex();
+    const ws = new Duplex();
     ws.wrap(s); //wraps the readable side of things
     ws._write = function (chunk, encoding, callback) {
       return s.write(chunk, encoding, callback);

--- a/lib/credentials.js
+++ b/lib/credentials.js
@@ -8,7 +8,7 @@
 //  * PLAIN (send username and password in the plain)
 //  * EXTERNAL (assume the server will figure out who you are from
 //    context, i.e., your SSL certificate)
-var codec = require('./codec');
+const codec = require('./codec');
 
 module.exports.plain = function (user, passwd) {
   return {

--- a/lib/error.js
+++ b/lib/error.js
@@ -1,11 +1,11 @@
-var inherits = require('util').inherits;
+const inherits = require('util').inherits;
 
 function trimStack(stack, num) {
   return stack && stack.split('\n').slice(num).join('\n');
 }
 
 function IllegalOperationError(msg, stack) {
-  var tmp = new Error();
+  const tmp = new Error();
   this.message = msg;
   this.stack = this.toString() + '\n' + trimStack(tmp.stack, 2);
   this.stackAtStateChange = stack;
@@ -15,7 +15,7 @@ inherits(IllegalOperationError, Error);
 IllegalOperationError.prototype.name = 'IllegalOperationError';
 
 function stackCapture(reason) {
-  var e = new Error();
+  const e = new Error();
   return 'Stack capture: ' + reason + '\n' + trimStack(e.stack, 2);
 }
 

--- a/lib/format.js
+++ b/lib/format.js
@@ -6,12 +6,12 @@
 
 'use strict';
 
-var defs = require('./defs');
-var format = require('util').format;
-var HEARTBEAT = require('./frame').HEARTBEAT;
+const defs = require('./defs');
+const format = require('util').format;
+const HEARTBEAT = require('./frame').HEARTBEAT;
 
 module.exports.closeMessage = function (close) {
-  var code = close.fields.replyCode;
+  const code = close.fields.replyCode;
   return format('%d (%s) with message "%s"', code, defs.constant_strs[code], close.fields.replyText);
 };
 
@@ -25,7 +25,7 @@ module.exports.inspect = function (frame, showFields) {
   } else if (!frame.id) {
     return format('<Content channel:%d size:%d>', frame.channel, frame.size);
   } else {
-    var info = defs.info(frame.id);
+    const info = defs.info(frame.id);
     return format('<%s channel:%d%s>', info.name, frame.channel, showFields ? ' ' + JSON.stringify(frame.fields, undefined, 2) : '');
   }
 };

--- a/lib/frame.js
+++ b/lib/frame.js
@@ -5,9 +5,9 @@
 'use strict';
 
 const ints = require('buffer-more-ints');
-var defs = require('./defs');
-var constants = defs.constants;
-var decode = defs.decode;
+const defs = require('./defs');
+const constants = defs.constants;
+const decode = defs.decode;
 
 module.exports.PROTOCOL_HEADER = 'AMQP' + String.fromCharCode(0, 0, 9, 1);
 
@@ -26,7 +26,7 @@ module.exports.PROTOCOL_HEADER = 'AMQP' + String.fromCharCode(0, 0, 9, 1);
 */
 
 // framing constants
-var FRAME_METHOD = constants.FRAME_METHOD,
+const FRAME_METHOD = constants.FRAME_METHOD,
   FRAME_HEARTBEAT = constants.FRAME_HEARTBEAT,
   FRAME_HEADER = constants.FRAME_HEADER,
   FRAME_BODY = constants.FRAME_BODY,
@@ -131,7 +131,7 @@ function parseFrame(bin) {
 
 module.exports.parseFrame = parseFrame;
 
-var HEARTBEAT = {channel: 0};
+const HEARTBEAT = {channel: 0};
 
 /**
  * Decode AMQP frame into JS object

--- a/lib/heartbeat.js
+++ b/lib/heartbeat.js
@@ -47,7 +47,7 @@
 
 'use strict';
 
-var EventEmitter = require('events');
+const EventEmitter = require('events');
 
 // Exported so that we can mess with it in tests
 module.exports.UNITS_TO_MS = 1000;
@@ -58,15 +58,15 @@ class Heart extends EventEmitter {
 
     this.interval = interval;
 
-    var intervalMs = interval * module.exports.UNITS_TO_MS;
+    const intervalMs = interval * module.exports.UNITS_TO_MS;
     // Function#bind is my new best friend
-    var beat = this.emit.bind(this, 'beat');
-    var timeout = this.emit.bind(this, 'timeout');
+    const beat = this.emit.bind(this, 'beat');
+    const timeout = this.emit.bind(this, 'timeout');
 
     this.sendTimer = setInterval(this.runHeartbeat.bind(this, checkSend, beat), intervalMs / 2);
 
     // A timeout occurs if I see nothing for *two consecutive* intervals
-    var recvMissed = 0;
+    let recvMissed = 0;
     function missedTwo() {
       if (!checkRecv()) return ++recvMissed < 2;
       else {

--- a/lib/mux.js
+++ b/lib/mux.js
@@ -8,9 +8,9 @@
 // it then writes 'packets' from the upstreams to the given
 // downstream.
 
-var assert = require('assert');
+const assert = require('assert');
 
-var schedule = typeof setImmediate === 'function' ? setImmediate : process.nextTick;
+const schedule = typeof setImmediate === 'function' ? setImmediate : process.nextTick;
 
 class Mux {
   constructor(downstream) {
@@ -20,7 +20,7 @@ class Mux {
     this.scheduledRead = false;
 
     this.out = downstream;
-    var self = this;
+    const self = this;
     downstream.on('drain', function () {
       self.blocked = false;
       self._readIncoming();
@@ -41,15 +41,15 @@ class Mux {
     // become readable
     if (this.blocked) return;
 
-    var accepting = true;
-    var out = this.out;
+    let accepting = true;
+    const out = this.out;
 
     // Try to read a chunk from each stream in turn, until all streams
     // are empty, or we exhaust our ability to accept chunks.
     function roundrobin(streams) {
-      var s;
+      let s;
       while (accepting && (s = streams.shift())) {
-        var chunk = s.read();
+        const chunk = s.read();
         if (chunk !== null) {
           accepting = out.write(chunk);
           streams.push(s);
@@ -82,7 +82,7 @@ class Mux {
   }
 
   _scheduleRead() {
-    var self = this;
+    const self = this;
 
     if (!self.scheduledRead) {
       schedule(function () {
@@ -94,7 +94,7 @@ class Mux {
   }
 
   pipeFrom(readable) {
-    var self = this;
+    const self = this;
 
     function enqueue() {
       self.newStreams.push(readable);

--- a/test/callback_api.js
+++ b/test/callback_api.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var assert = require('assert');
-var api = require('../callback_api');
-var util = require('./util');
-var schedule = util.schedule;
-var randomString = util.randomString;
-var kCallback = util.kCallback;
-var domain = require('domain');
+const assert = require('assert');
+const api = require('../callback_api');
+const util = require('./util');
+const schedule = util.schedule;
+const randomString = util.randomString;
+const kCallback = util.kCallback;
+const domain = require('domain');
 
-var URL = process.env.URL || 'amqp://localhost';
+const URL = process.env.URL || 'amqp://localhost';
 
 function connect(cb) {
   api.connect(URL, {}, cb);
@@ -25,11 +25,11 @@ function doneCallback(done) {
 function ignore() {}
 
 function twice(done) {
-  var first = function (err) {
+  let first = function (err) {
     if (err == undefined) second = done;
     else (second = ignore), done(err);
   };
-  var second = function (err) {
+  let second = function (err) {
     if (err == undefined) first = done;
     else (first = ignore), done(err);
   };
@@ -95,8 +95,8 @@ function channel_test_fn(method) {
     });
   };
 }
-var channel_test = channel_test_fn('createChannel');
-var confirm_channel_test = channel_test_fn('createConfirmChannel');
+const channel_test = channel_test_fn('createChannel');
+const confirm_channel_test = channel_test_fn('createConfirmChannel');
 
 suite('channel open', function () {
   channel_test('at all', function (_ch, done) {
@@ -141,13 +141,13 @@ suite('assert, check, delete', function () {
   });
 
   channel_test('fail on check non-queue', function (ch, done) {
-    var both = twice(done);
+    const both = twice(done);
     ch.on('error', failCallback(both.first));
     ch.checkQueue('test.cb.nothere', failCallback(both.second));
   });
 
   channel_test('fail on check non-exchange', function (ch, done) {
-    var both = twice(done);
+    const both = twice(done);
     ch.on('error', failCallback(both.first));
     ch.checkExchange('test.cb.nothere', failCallback(both.second));
   });
@@ -192,7 +192,7 @@ suite('bindings', function () {
 
 suite('sending messages', function () {
   channel_test('send to queue and consume noAck', function (ch, done) {
-    var msg = randomString();
+    const msg = randomString();
     ch.assertQueue('', {exclusive: true}, function (e, q) {
       if (e !== null) return done(e);
       ch.consume(
@@ -208,7 +208,7 @@ suite('sending messages', function () {
   });
 
   channel_test('send to queue and consume ack', function (ch, done) {
-    var msg = randomString();
+    const msg = randomString();
     ch.assertQueue('', {exclusive: true}, function (e, q) {
       if (e !== null) return done(e);
       ch.consume(
@@ -228,7 +228,7 @@ suite('sending messages', function () {
   channel_test('send to and get from queue', function (ch, done) {
     ch.assertQueue('', {exclusive: true}, function (e, q) {
       if (e != null) return done(e);
-      var msg = randomString();
+      const msg = randomString();
       ch.sendToQueue(q.queue, Buffer.from(msg));
       waitForMessages(ch, q.queue, function (e, _) {
         if (e != null) return done(e);
@@ -242,11 +242,11 @@ suite('sending messages', function () {
     });
   });
 
-  var channelOptions = {};
+  const channelOptions = {};
 
   channel_test('find high watermark', function (ch, done) {
-    var msg = randomString();
-    var baseline = 0;
+    const msg = randomString();
+    let baseline = 0;
     ch.assertQueue('', {exclusive: true}, function (e, q) {
       if (e !== null) return done(e);
       while (ch.sendToQueue(q.queue, Buffer.from(msg))) {
@@ -258,11 +258,11 @@ suite('sending messages', function () {
   });
 
   channel_test('set high watermark', channelOptions, function (ch, done) {
-    var msg = randomString();
+    const msg = randomString();
     ch.assertQueue('', {exclusive: true}, function (e, q) {
       if (e !== null) return done(e);
-      var ok;
-      for (var i = 0; i < channelOptions.highWaterMark; i++) {
+      let ok;
+      for (let i = 0; i < channelOptions.highWaterMark; i++) {
         ok = ch.sendToQueue(q.queue, Buffer.from(msg));
         assert.equal(ok, true);
       }
@@ -280,17 +280,17 @@ suite('ConfirmChannel', function () {
   });
 
   confirm_channel_test('Wait for confirms', function (ch, done) {
-    for (var i = 0; i < 1000; i++) {
+    for (let i = 0; i < 1000; i++) {
       ch.publish('', '', Buffer.from('foo'), {});
     }
     ch.waitForConfirms(done);
   });
 
-  var channelOptions = {};
+  const channelOptions = {};
 
   confirm_channel_test('find high watermark', function (ch, done) {
-    var msg = randomString();
-    var baseline = 0;
+    const msg = randomString();
+    let baseline = 0;
     ch.assertQueue('', {exclusive: true}, function (e, q) {
       if (e !== null) return done(e);
       while (ch.sendToQueue(q.queue, Buffer.from(msg))) {
@@ -302,11 +302,11 @@ suite('ConfirmChannel', function () {
   });
 
   confirm_channel_test('set high watermark', channelOptions, function (ch, done) {
-    var msg = randomString();
+    const msg = randomString();
     ch.assertQueue('', {exclusive: true}, function (e, q) {
       if (e !== null) return done(e);
-      var ok;
-      for (var i = 0; i < channelOptions.highWaterMark; i++) {
+      let ok;
+      for (let i = 0; i < channelOptions.highWaterMark; i++) {
         ok = ch.sendToQueue(q.queue, Buffer.from(msg));
         assert.equal(ok, true);
       }
@@ -331,7 +331,7 @@ suite('Error handling', function () {
    */
   if (util.versionGreaterThan(process.versions.node, '0.8')) {
     test('Throw error in connection open callback', function (done) {
-      var dom = domain.createDomain();
+      const dom = domain.createDomain();
       dom.on('error', failCallback(done));
       connect(
         dom.bind(function (_err, _conn) {
@@ -344,7 +344,7 @@ suite('Error handling', function () {
   // TODO: refactor {error_test, channel_test}
   function error_test(name, fun) {
     test(name, function (done) {
-      var dom = domain.createDomain();
+      const dom = domain.createDomain();
       dom.run(function () {
         connect(
           kCallback(function (c) {
@@ -396,13 +396,13 @@ suite('Error handling', function () {
   });
 
   error_test('Get from non-queue invokes error k', function (ch, done, dom) {
-    var both = twice(failCallback(done));
+    const both = twice(failCallback(done));
     dom.on('error', both.first);
     ch.get('', {}, both.second);
   });
 
   error_test('Consume from non-queue invokes error k', function (ch, done, dom) {
-    var both = twice(failCallback(done));
+    const both = twice(failCallback(done));
     dom.on('error', both.first);
     ch.consume('', both.second);
   });

--- a/test/channel.js
+++ b/test/channel.js
@@ -2,26 +2,26 @@
 
 'use strict';
 
-var assert = require('assert');
-var promisify = require('util').promisify;
-var Channel = require('../lib/channel').Channel;
-var Connection = require('../lib/connection').Connection;
-var util = require('./util');
-var succeed = util.succeed,
+const assert = require('assert');
+const promisify = require('util').promisify;
+const Channel = require('../lib/channel').Channel;
+const Connection = require('../lib/connection').Connection;
+const util = require('./util');
+const succeed = util.succeed,
   fail = util.fail,
   latch = util.latch;
-var completes = util.completes;
-var defs = require('../lib/defs');
-var conn_handshake = require('./connection').connection_handshake;
-var OPEN_OPTS = require('./connection').OPEN_OPTS;
+const completes = util.completes;
+const defs = require('../lib/defs');
+const conn_handshake = require('./connection').connection_handshake;
+const OPEN_OPTS = require('./connection').OPEN_OPTS;
 
-var LOG_ERRORS = process.env.LOG_ERRORS;
+const LOG_ERRORS = process.env.LOG_ERRORS;
 
 function baseChannelTest(client, server) {
   return function (done) {
-    var bothDone = latch(2, done);
-    var pair = util.socketPair();
-    var c = new Connection(pair.client);
+    const bothDone = latch(2, done);
+    const pair = util.socketPair();
+    const c = new Connection(pair.client);
 
     if (LOG_ERRORS) c.on('error', console.warn);
 
@@ -42,7 +42,7 @@ function baseChannelTest(client, server) {
 function channelTest(client, server) {
   return baseChannelTest(
     function (conn, done) {
-      var ch = new Channel(conn);
+      const ch = new Channel(conn);
       if (LOG_ERRORS) ch.on('error', console.warn);
       client(ch, done, conn);
     },
@@ -66,7 +66,7 @@ function channel_handshake(send, wait) {
 }
 
 // fields for deliver and publish and get-ok
-var DELIVER_FIELDS = {
+const DELIVER_FIELDS = {
   consumerTag: 'fake',
   deliveryTag: 1,
   redelivered: false,
@@ -100,7 +100,7 @@ suite('channel open and close', function () {
     'bad server',
     baseChannelTest(
       function (c, done) {
-        var ch = new Channel(c);
+        const ch = new Channel(c);
         open(ch).then(fail(done), succeed(done));
       },
       function (send, wait, done) {
@@ -167,7 +167,7 @@ suite('channel open and close', function () {
     'overlapping channel/server close',
     channelTest(
       function (ch, done, conn) {
-        var both = latch(2, done);
+        const both = latch(2, done);
         conn.on('error', succeed(both));
         ch.on('close', succeed(both));
         open(ch).then(function () {
@@ -224,7 +224,7 @@ suite('channel machinery', function () {
     'RPC',
     channelTest(
       function (ch, done) {
-        var rpcLatch = latch(3, done);
+        const rpcLatch = latch(3, done);
         open(ch)
           .then(function () {
             function wheeboom(err, _f) {
@@ -232,7 +232,7 @@ suite('channel machinery', function () {
               else rpcLatch();
             }
 
-            var fields = {
+            const fields = {
               prefetchCount: 10,
               prefetchSize: 0,
               global: false,
@@ -266,7 +266,7 @@ suite('channel machinery', function () {
       function (ch, done) {
         // We want to see the RPC rejected and the channel closed (with an
         // error)
-        var errLatch = latch(2, done);
+        const errLatch = latch(2, done);
         ch.on('error', function (error) {
           assert.strictEqual(505, error.code);
           assert.strictEqual(60, error.classId);
@@ -301,7 +301,7 @@ suite('channel machinery', function () {
       function (ch, done) {
         open(ch);
 
-        var close = new Promise(function (resolve) {
+        const close = new Promise(function (resolve) {
           ch.on('error', function (error) {
             assert.strictEqual(504, error.code);
             assert.strictEqual(0, error.classId);
@@ -317,11 +317,11 @@ suite('channel machinery', function () {
           };
         }
 
-        var fail1 = new Promise(function (resolve, reject) {
+        const fail1 = new Promise(function (resolve, reject) {
           return ch._rpc(defs.BasicRecover, {requeue: true}, defs.BasicRecoverOk, failureCb(resolve, reject));
         });
 
-        var fail2 = new Promise(function (resolve, reject) {
+        const fail2 = new Promise(function (resolve, reject) {
           return ch._rpc(defs.BasicRecover, {requeue: true}, defs.BasicRecoverOk, failureCb(resolve, reject));
         });
 
@@ -526,7 +526,7 @@ suite('channel machinery', function () {
     'bad delivery',
     channelTest(
       function (ch, done) {
-        var errorAndClose = latch(2, done);
+        const errorAndClose = latch(2, done);
         ch.on('error', function (error) {
           assert.strictEqual(505, error.code);
           assert.strictEqual(60, error.classId);
@@ -587,7 +587,7 @@ suite('channel machinery', function () {
     'bad consumer',
     channelTest(
       function (ch, done) {
-        var errorAndClose = latch(2, done);
+        const errorAndClose = latch(2, done);
         ch.on('delivery', function () {
           throw new Error('I am a bad consumer');
         });
@@ -615,7 +615,7 @@ suite('channel machinery', function () {
     'bad send in consumer',
     channelTest(
       function (ch, done) {
-        var errorAndClose = latch(2, done);
+        const errorAndClose = latch(2, done);
         ch.on('close', succeed(errorAndClose));
         ch.on('error', function (error) {
           assert.strictEqual(541, error.code);
@@ -723,7 +723,7 @@ suite('channel machinery', function () {
     'out-of-order acks',
     channelTest(
       function (ch, done) {
-        var allConfirms = latch(3, function () {
+        const allConfirms = latch(3, function () {
           completes(function () {
             assert.equal(0, ch.unconfirmed.length);
             assert.equal(4, ch.lwm);
@@ -748,7 +748,7 @@ suite('channel machinery', function () {
     'not all out-of-order acks',
     channelTest(
       function (ch, done) {
-        var allConfirms = latch(2, function () {
+        const allConfirms = latch(2, function () {
           completes(function () {
             assert.equal(1, ch.unconfirmed.length);
             assert.equal(3, ch.lwm);

--- a/test/channel_api.js
+++ b/test/channel_api.js
@@ -1,15 +1,15 @@
 'use strict';
 
-var assert = require('assert');
-var api = require('../channel_api');
-var util = require('./util');
-var succeed = util.succeed,
+const assert = require('assert');
+const api = require('../channel_api');
+const util = require('./util');
+const succeed = util.succeed,
   fail = util.fail;
-var schedule = util.schedule;
-var randomString = util.randomString;
-var promisify = require('util').promisify;
+const schedule = util.schedule;
+const randomString = util.randomString;
+const promisify = require('util').promisify;
 
-var URL = process.env.URL || 'amqp://localhost';
+const URL = process.env.URL || 'amqp://localhost';
 
 function connect() {
   return api.connect(URL);
@@ -54,7 +54,7 @@ function channel_test(chmethod, name, chfun) {
   });
 }
 
-var chtest = channel_test.bind(null, 'createChannel');
+const chtest = channel_test.bind(null, 'createChannel');
 
 suite('connect', function () {
   test('at all', function (done) {
@@ -80,8 +80,8 @@ suite('updateSecret', function () {
   });
 });
 
-var QUEUE_OPTS = {durable: false};
-var EX_OPTS = {durable: false};
+const QUEUE_OPTS = {durable: false};
+const EX_OPTS = {durable: false};
 
 suite('assert, check, delete', function () {
   chtest('assert and check queue', function (ch) {
@@ -98,7 +98,7 @@ suite('assert, check, delete', function () {
   });
 
   chtest('fail on reasserting queue with different options', function (ch) {
-    var q = 'test.reassert-queue';
+    const q = 'test.reassert-queue';
     return ch.assertQueue(q, {durable: false, autoDelete: true}).then(function () {
       return expectFail(ch.assertQueue(q, {durable: false, autoDelete: false}));
     });
@@ -113,7 +113,7 @@ suite('assert, check, delete', function () {
   });
 
   chtest('fail on reasserting exchange with different type', function (ch) {
-    var ex = 'test.reassert-ex';
+    const ex = 'test.reassert-ex';
     return ch.assertExchange(ex, 'fanout', EX_OPTS).then(function () {
       return expectFail(ch.assertExchange(ex, 'direct', EX_OPTS));
     });
@@ -127,7 +127,7 @@ suite('assert, check, delete', function () {
   });
 
   chtest('delete queue', function (ch) {
-    var q = 'test.delete-queue';
+    const q = 'test.delete-queue';
     return Promise.all([ch.assertQueue(q, QUEUE_OPTS), ch.checkQueue(q)])
       .then(function () {
         return ch.deleteQueue(q);
@@ -138,7 +138,7 @@ suite('assert, check, delete', function () {
   });
 
   chtest('delete exchange', function (ch) {
-    var ex = 'test.delete-exchange';
+    const ex = 'test.delete-exchange';
     return Promise.all([ch.assertExchange(ex, 'fanout', EX_OPTS), ch.checkExchange(ex)])
       .then(function () {
         return ch.deleteExchange(ex);
@@ -172,7 +172,7 @@ function waitForQueue(q, condition) {
 // Return a promise that resolves when the queue has at least `num`
 // messages. If num is not supplied its assumed to be 1.
 function waitForMessages(q, num) {
-  var min = num === undefined ? 1 : num;
+  const min = num === undefined ? 1 : num;
   return waitForQueue(q, function (qok) {
     return qok.messageCount >= min;
   });
@@ -181,8 +181,8 @@ function waitForMessages(q, num) {
 suite('sendMessage', function () {
   // publish different size messages
   chtest('send to queue and get from queue', function (ch) {
-    var q = 'test.send-to-q';
-    var msg = randomString();
+    const q = 'test.send-to-q';
+    const msg = randomString();
     return Promise.all([ch.assertQueue(q, QUEUE_OPTS), ch.purgeQueue(q)])
       .then(function () {
         ch.sendToQueue(q, Buffer.from(msg));
@@ -198,8 +198,8 @@ suite('sendMessage', function () {
   });
 
   chtest('send (and get) zero content to queue', function (ch) {
-    var q = 'test.send-to-q';
-    var msg = Buffer.alloc(0);
+    const q = 'test.send-to-q';
+    const msg = Buffer.alloc(0);
     return Promise.all([ch.assertQueue(q, QUEUE_OPTS), ch.purgeQueue(q)])
       .then(function () {
         ch.sendToQueue(q, msg);
@@ -218,9 +218,9 @@ suite('sendMessage', function () {
 suite('binding, consuming', function () {
   // bind, publish, get
   chtest('route message', function (ch) {
-    var ex = 'test.route-message';
-    var q = 'test.route-message-q';
-    var msg = randomString();
+    const ex = 'test.route-message';
+    const q = 'test.route-message-q';
+    const msg = randomString();
 
     return Promise.all([
       ch.assertExchange(ex, 'fanout', EX_OPTS),
@@ -243,7 +243,7 @@ suite('binding, consuming', function () {
 
   // send to queue, purge, get-empty
   chtest('purge queue', function (ch) {
-    var q = 'test.purge-queue';
+    const q = 'test.purge-queue';
     return ch
       .assertQueue(q, {durable: false})
       .then(function () {
@@ -261,10 +261,10 @@ suite('binding, consuming', function () {
 
   // bind again, unbind, publish, get-empty
   chtest('unbind queue', function (ch) {
-    var ex = 'test.unbind-queue-ex';
-    var q = 'test.unbind-queue';
-    var viabinding = randomString();
-    var direct = randomString();
+    const ex = 'test.unbind-queue-ex';
+    const q = 'test.unbind-queue';
+    const viabinding = randomString();
+    const direct = randomString();
 
     return Promise.all([
       ch.assertExchange(ex, 'fanout', EX_OPTS),
@@ -305,10 +305,10 @@ suite('binding, consuming', function () {
   // To some extent this is now just testing semantics of the server,
   // but we can at least try out a few settings, and consume.
   chtest('consume via exchange-exchange binding', function (ch) {
-    var ex1 = 'test.ex-ex-binding1',
+    const ex1 = 'test.ex-ex-binding1',
       ex2 = 'test.ex-ex-binding2';
-    var q = 'test.ex-ex-binding-q';
-    var rk = 'test.routing.key',
+    const q = 'test.ex-ex-binding-q';
+    const rk = 'test.routing.key',
       msg = randomString();
     return Promise.all([
       ch.assertExchange(ex1, 'direct', EX_OPTS),
@@ -332,11 +332,11 @@ suite('binding, consuming', function () {
 
   // bind again, unbind, publish, get-empty
   chtest('unbind exchange', function (ch) {
-    var source = 'test.unbind-ex-source';
-    var dest = 'test.unbind-ex-dest';
-    var q = 'test.unbind-ex-queue';
-    var viabinding = randomString();
-    var direct = randomString();
+    const source = 'test.unbind-ex-source';
+    const dest = 'test.unbind-ex-dest';
+    const q = 'test.unbind-ex-queue';
+    const viabinding = randomString();
+    const direct = randomString();
 
     return Promise.all([
       ch.assertExchange(source, 'fanout', EX_OPTS),
@@ -378,9 +378,9 @@ suite('binding, consuming', function () {
 
   // This is a bit convoluted. Sorry.
   chtest('cancel consumer', function (ch) {
-    var q = 'test.consumer-cancel';
-    var ctag;
-    var recv1 = new Promise(function (resolve, _reject) {
+    const q = 'test.consumer-cancel';
+    let ctag;
+    const recv1 = new Promise(function (resolve, _reject) {
       Promise.all([
         ch.assertQueue(q, QUEUE_OPTS),
         ch.purgeQueue(q),
@@ -396,7 +396,7 @@ suite('binding, consuming', function () {
 
     // A message should arrive because of the consume
     return recv1.then(function () {
-      var recv2 = Promise.all([
+      const recv2 = Promise.all([
         ch.cancel(ctag).then(function () {
           return ch.sendToQueue(q, Buffer.from('bar'));
         }),
@@ -419,7 +419,7 @@ suite('binding, consuming', function () {
   });
 
   chtest('cancelled consumer', function (ch) {
-    var q = 'test.cancelled-consumer';
+    const q = 'test.cancelled-consumer';
     return new Promise(function (resolve, reject) {
       return Promise.all([
         ch.assertQueue(q),
@@ -436,8 +436,8 @@ suite('binding, consuming', function () {
 
   // ack, by default, removes a single message from the queue
   chtest('ack', function (ch) {
-    var q = 'test.ack';
-    var msg1 = randomString(),
+    const q = 'test.ack';
+    const msg1 = randomString(),
       msg2 = randomString();
 
     return Promise.all([ch.assertQueue(q, QUEUE_OPTS), ch.purgeQueue(q)])
@@ -465,8 +465,8 @@ suite('binding, consuming', function () {
   // Nack, by default, puts a message back on the queue (where in the
   // queue is up to the server)
   chtest('nack', function (ch) {
-    var q = 'test.nack';
-    var msg1 = randomString();
+    const q = 'test.nack';
+    const msg1 = randomString();
 
     return Promise.all([ch.assertQueue(q, QUEUE_OPTS), ch.purgeQueue(q)])
       .then(function () {
@@ -493,8 +493,8 @@ suite('binding, consuming', function () {
   // reject is a near-synonym for nack, the latter of which is not
   // available in earlier RabbitMQ (or in AMQP proper).
   chtest('reject', function (ch) {
-    var q = 'test.reject';
-    var msg1 = randomString();
+    const q = 'test.reject';
+    const msg1 = randomString();
 
     return Promise.all([ch.assertQueue(q, QUEUE_OPTS), ch.purgeQueue(q)])
       .then(function () {
@@ -519,7 +519,7 @@ suite('binding, consuming', function () {
   });
 
   chtest('prefetch', function (ch) {
-    var q = 'test.prefetch';
+    const q = 'test.prefetch';
     return Promise.all([ch.assertQueue(q, QUEUE_OPTS), ch.purgeQueue(q), ch.prefetch(1)])
       .then(function () {
         ch.sendToQueue(q, Buffer.from('foobar'));
@@ -528,7 +528,7 @@ suite('binding, consuming', function () {
       })
       .then(function () {
         return new Promise(function (resolve) {
-          var messageCount = 0;
+          let messageCount = 0;
           function receive(msg) {
             ch.ack(msg);
             if (++messageCount > 1) {
@@ -550,11 +550,11 @@ suite('binding, consuming', function () {
   });
 });
 
-var confirmtest = channel_test.bind(null, 'createConfirmChannel');
+const confirmtest = channel_test.bind(null, 'createConfirmChannel');
 
 suite('confirms', function () {
   confirmtest('message is confirmed', function (ch) {
-    var q = 'test.confirm-message';
+    const q = 'test.confirm-message';
     return Promise.all([ch.assertQueue(q, QUEUE_OPTS), ch.purgeQueue(q)]).then(function () {
       return ch.sendToQueue(q, Buffer.from('bleep'));
     });
@@ -566,24 +566,24 @@ suite('confirms', function () {
   // the acknowledgements coming through to see if we really did get a
   // multi-ack.
   confirmtest('multiple confirms', function (ch) {
-    var q = 'test.multiple-confirms';
+    const q = 'test.multiple-confirms';
     return Promise.all([ch.assertQueue(q, QUEUE_OPTS), ch.purgeQueue(q)]).then(function () {
-      var multipleRainbows = false;
+      let multipleRainbows = false;
       ch.on('ack', function (a) {
         if (a.multiple) multipleRainbows = true;
       });
 
       function prod(num) {
-        var cs = [];
+        const cs = [];
 
         function sendAndPushPromise() {
-          var conf = promisify(function (cb) {
+          const conf = promisify(function (cb) {
             return ch.sendToQueue(q, Buffer.from('bleep'), {}, cb);
           })();
           cs.push(conf);
         }
 
-        for (var i = 0; i < num; i++) sendAndPushPromise();
+        for (let i = 0; i < num; i++) sendAndPushPromise();
 
         return Promise.all(cs).then(function () {
           if (multipleRainbows) return true;
@@ -599,14 +599,14 @@ suite('confirms', function () {
   });
 
   confirmtest('wait for confirms', function (ch) {
-    for (var i = 0; i < 1000; i++) {
+    for (let i = 0; i < 1000; i++) {
       ch.publish('', '', Buffer.from('foobar'), {});
     }
     return ch.waitForConfirms();
   });
 
   confirmtest('works when channel is closed', function (ch) {
-    for (var i = 0; i < 1000; i++) {
+    for (let i = 0; i < 1000; i++) {
       ch.publish('', '', Buffer.from('foobar'), {});
     }
     return ch

--- a/test/codec.js
+++ b/test/codec.js
@@ -1,16 +1,16 @@
 'use strict';
 
-var codec = require('../lib/codec');
-var defs = require('../lib/defs');
-var assert = require('assert');
-var ints = require('buffer-more-ints');
-var C = require('claire');
-var forAll = C.forAll;
+const codec = require('../lib/codec');
+const defs = require('../lib/defs');
+const assert = require('assert');
+const ints = require('buffer-more-ints');
+const C = require('claire');
+const forAll = C.forAll;
 
 // These just test known encodings; to generate the answers I used
 // RabbitMQ's binary generator module.
 
-var testCases = [
+const testCases = [
   // integers
   ['byte', {byte: 112}, [4, 98, 121, 116, 101, 98, 112]],
   ['byte max value', {byte: 127}, [4, 98, 121, 116, 101, 98, 127]],
@@ -81,13 +81,13 @@ function bufferToArray(b) {
 
 suite('Implicit encodings', function () {
   testCases.forEach(function (tc) {
-    var name = tc[0],
+    const name = tc[0],
       val = tc[1],
       expect = tc[2];
     test(name, function () {
-      var buffer = Buffer.alloc(1000);
-      var size = codec.encodeTable(buffer, val, 0);
-      var result = buffer.subarray(4, size);
+      const buffer = Buffer.alloc(1000);
+      const size = codec.encodeTable(buffer, val, 0);
+      const result = buffer.subarray(4, size);
       assert.deepEqual(expect, bufferToArray(result));
     });
   });
@@ -95,12 +95,12 @@ suite('Implicit encodings', function () {
 
 // Whole frames
 
-var amqp = require('./data');
+const amqp = require('./data');
 
 function roundtrip_table(t) {
-  var buf = Buffer.alloc(4096);
-  var size = codec.encodeTable(buf, t, 0);
-  var decoded = codec.decodeFields(buf.subarray(4, size)); // ignore the length-prefix
+  const buf = Buffer.alloc(4096);
+  const size = codec.encodeTable(buf, t, 0);
+  const decoded = codec.decodeFields(buf.subarray(4, size)); // ignore the length-prefix
   try {
     assert.deepEqual(removeExplicitTypes(t), decoded);
   } catch {
@@ -151,8 +151,8 @@ function removeExplicitTypes(input) {
         return null;
       }
       if (Array.isArray(input)) {
-        var newArr = [];
-        for (var i = 0; i < input.length; i++) {
+        const newArr = [];
+        for (let i = 0; i < input.length; i++) {
           newArr[i] = removeExplicitTypes(input[i]);
         }
         return newArr;
@@ -166,8 +166,8 @@ function removeExplicitTypes(input) {
         case 'float':
           return input;
         case undefined:
-          var newObj = {};
-          for (var k in input) {
+          const newObj = {};
+          for (const k in input) {
             newObj[k] = removeExplicitTypes(input[k]);
           }
           return newObj;
@@ -191,11 +191,11 @@ function removeExplicitTypes(input) {
 // substituted for missing fields when decoding. The effect is the
 // same so far as these tests are concerned.
 function assertEqualModuloDefaults(original, decodedFields) {
-  var args = defs.info(original.id).args;
-  for (var i = 0; i < args.length; i++) {
-    var arg = args[i];
-    var originalValue = original.fields[arg.name];
-    var decodedValue = decodedFields[arg.name];
+  const args = defs.info(original.id).args;
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    const originalValue = original.fields[arg.name];
+    const decodedValue = decodedFields[arg.name];
     try {
       if (originalValue === undefined) {
         // longstr gets special treatment here, since the defaults are
@@ -206,7 +206,7 @@ function assertEqualModuloDefaults(original, decodedFields) {
         assert.deepEqual(removeExplicitTypes(originalValue), decodedValue);
       }
     } catch (assertionErr) {
-      var methodOrProps = defs.info(original.id).name;
+      const methodOrProps = defs.info(original.id).name;
       assertionErr.message += ' (frame ' + methodOrProps + ' field ' + arg.name + ')';
       throw assertionErr;
     }
@@ -220,9 +220,9 @@ module.exports.assertEqualModuloDefaults = assertEqualModuloDefaults;
 
 function roundtripMethod(Method) {
   return forAll(Method).satisfy(function (method) {
-    var buf = defs.encodeMethod(method.id, 0, method.fields);
+    const buf = defs.encodeMethod(method.id, 0, method.fields);
     // FIXME depends on framing, ugh
-    var fs1 = defs.decode(method.id, buf.subarray(11, buf.length));
+    const fs1 = defs.decode(method.id, buf.subarray(11, buf.length));
     assertEqualModuloDefaults(method, fs1);
     return true;
   });
@@ -230,9 +230,9 @@ function roundtripMethod(Method) {
 
 function roundtripProperties(Properties) {
   return forAll(Properties).satisfy(function (properties) {
-    var buf = defs.encodeProperties(properties.id, 0, properties.size, properties.fields);
+    const buf = defs.encodeProperties(properties.id, 0, properties.size, properties.fields);
     // FIXME depends on framing, ugh
-    var fs1 = defs.decode(properties.id, buf.subarray(19, buf.length));
+    const fs1 = defs.decode(properties.id, buf.subarray(19, buf.length));
     assert.equal(properties.size, ints.readUInt64BE(buf, 11));
     assertEqualModuloDefaults(properties, fs1);
     return true;

--- a/test/connect.js
+++ b/test/connect.js
@@ -1,21 +1,21 @@
 'use strict';
 
-var connect = require('../lib/connect').connect;
-var credentialsFromUrl = require('../lib/connect').credentialsFromUrl;
-var defs = require('../lib/defs');
-var assert = require('assert');
-var util = require('./util');
-var net = require('net');
-var fail = util.fail,
+const connect = require('../lib/connect').connect;
+const credentialsFromUrl = require('../lib/connect').credentialsFromUrl;
+const defs = require('../lib/defs');
+const assert = require('assert');
+const util = require('./util');
+const net = require('net');
+const fail = util.fail,
   succeed = util.succeed,
   latch = util.latch,
   kCallback = util.kCallback,
   succeedIfAttributeEquals = util.succeedIfAttributeEquals;
-var format = require('util').format;
+const format = require('util').format;
 
-var URL = process.env.URL || 'amqp://localhost';
+const URL = process.env.URL || 'amqp://localhost';
 
-var urlparse = require('url-parse');
+const urlparse = require('url-parse');
 
 suite('Credentials', function () {
   function checkCreds(creds, user, pass, done) {
@@ -29,28 +29,28 @@ suite('Credentials', function () {
   }
 
   test('no creds', function (done) {
-    var parts = urlparse('amqp://localhost');
-    var creds = credentialsFromUrl(parts);
+    const parts = urlparse('amqp://localhost');
+    const creds = credentialsFromUrl(parts);
     checkCreds(creds, 'guest', 'guest', done);
   });
   test('usual user:pass', function (done) {
-    var parts = urlparse('amqp://user:pass@localhost');
-    var creds = credentialsFromUrl(parts);
+    const parts = urlparse('amqp://user:pass@localhost');
+    const creds = credentialsFromUrl(parts);
     checkCreds(creds, 'user', 'pass', done);
   });
   test('missing user', function (done) {
-    var parts = urlparse('amqps://:password@localhost');
-    var creds = credentialsFromUrl(parts);
+    const parts = urlparse('amqps://:password@localhost');
+    const creds = credentialsFromUrl(parts);
     checkCreds(creds, '', 'password', done);
   });
   test('missing password', function (done) {
-    var parts = urlparse('amqps://username:@localhost');
-    var creds = credentialsFromUrl(parts);
+    const parts = urlparse('amqps://username:@localhost');
+    const creds = credentialsFromUrl(parts);
     checkCreds(creds, 'username', '', done);
   });
   test('escaped colons', function (done) {
-    var parts = urlparse('amqp://user%3Aname:pass%3Aword@localhost');
-    var creds = credentialsFromUrl(parts);
+    const parts = urlparse('amqp://user%3Aname:pass%3Aword@localhost');
+    const creds = credentialsFromUrl(parts);
     checkCreds(creds, 'user:name', 'pass:word', done);
   });
 });
@@ -68,19 +68,19 @@ suite('Connect API', function () {
   });
 
   test('wrongly typed open option', function (done) {
-    var url = require('url');
-    var parts = url.parse(URL, true);
-    var q = parts.query || {};
+    const url = require('url');
+    const parts = url.parse(URL, true);
+    const q = parts.query || {};
     q.frameMax = 'NOT A NUMBER';
     parts.query = q;
-    var u = url.format(parts);
+    const u = url.format(parts);
     connect(u, {}, kCallback(fail(done), succeed(done)));
   });
 
   test('serverProperties', function (done) {
-    var url = require('url');
-    var parts = url.parse(URL, true);
-    var config = parts.query || {};
+    const url = require('url');
+    const parts = url.parse(URL, true);
+    const config = parts.query || {};
     connect(config, {}, function (err, connection) {
       if (err) {
         return done(err);
@@ -91,40 +91,40 @@ suite('Connect API', function () {
   });
 
   test('using custom heartbeat option', function (done) {
-    var url = require('url');
-    var parts = url.parse(URL, true);
-    var config = parts.query || {};
+    const url = require('url');
+    const parts = url.parse(URL, true);
+    const config = parts.query || {};
     config.heartbeat = 20;
     connect(config, {}, kCallback(succeedIfAttributeEquals('heartbeat', 20, done), fail(done)));
   });
 
   test('wrongly typed heartbeat option', function (done) {
-    var url = require('url');
-    var parts = url.parse(URL, true);
-    var config = parts.query || {};
+    const url = require('url');
+    const parts = url.parse(URL, true);
+    const config = parts.query || {};
     config.heartbeat = 'NOT A NUMBER';
     connect(config, {}, kCallback(fail(done), succeed(done)));
   });
 
   test('using plain credentials', function (done) {
-    var url = require('url');
-    var parts = url.parse(URL, true);
-    var u = 'guest',
+    const url = require('url');
+    const parts = url.parse(URL, true);
+    let u = 'guest',
       p = 'guest';
     if (parts.auth) {
-      var auth = parts.auth.split(':');
+      const auth = parts.auth.split(':');
       (u = auth[0]), (p = auth[1]);
     }
     connect(URL, {credentials: require('../lib/credentials').plain(u, p)}, kCallback(succeed(done), fail(done)));
   });
 
   test('using amqplain credentials', function (done) {
-    var url = require('url');
-    var parts = url.parse(URL, true);
-    var u = 'guest',
+    const url = require('url');
+    const parts = url.parse(URL, true);
+    let u = 'guest',
       p = 'guest';
     if (parts.auth) {
-      var auth = parts.auth.split(':');
+      const auth = parts.auth.split(':');
       (u = auth[0]), (p = auth[1]);
     }
     connect(URL, {credentials: require('../lib/credentials').amqplain(u, p)}, kCallback(succeed(done), fail(done)));
@@ -140,7 +140,7 @@ suite('Connect API', function () {
   });
 
   test('using unsupported mechanism', function (done) {
-    var creds = {
+    const creds = {
       mechanism: 'UNSUPPORTED',
       response: function () {
         return Buffer.from('');
@@ -150,7 +150,7 @@ suite('Connect API', function () {
   });
 
   test('with a given connection timeout', function (done) {
-    var timeoutServer = net.createServer(function () {}).listen(31991);
+    const timeoutServer = net.createServer(function () {}).listen(31991);
 
     connect('amqp://localhost:31991', {timeout: 50}, function (_err, val) {
       timeoutServer.close();
@@ -161,7 +161,7 @@ suite('Connect API', function () {
 });
 
 suite('Errors on connect', function () {
-  var server;
+  let server;
   teardown(function () {
     if (server) {
       server.close();
@@ -169,7 +169,7 @@ suite('Errors on connect', function () {
   });
 
   test('closes underlying connection on authentication error', function (done) {
-    var bothDone = latch(2, done);
+    const bothDone = latch(2, done);
     server = net
       .createServer(function (socket) {
         socket.once('data', function (protocolHeader) {

--- a/test/connection.js
+++ b/test/connection.js
@@ -1,20 +1,20 @@
 'use strict';
 
-var assert = require('assert');
-var defs = require('../lib/defs');
-var Connection = require('../lib/connection').Connection;
-var HEARTBEAT = require('../lib/frame').HEARTBEAT;
-var HB_BUF = require('../lib/frame').HEARTBEAT_BUF;
-var util = require('./util');
-var succeed = util.succeed,
+const assert = require('assert');
+const defs = require('../lib/defs');
+const Connection = require('../lib/connection').Connection;
+const HEARTBEAT = require('../lib/frame').HEARTBEAT;
+const HB_BUF = require('../lib/frame').HEARTBEAT_BUF;
+const util = require('./util');
+const succeed = util.succeed,
   fail = util.fail,
   latch = util.latch;
-var completes = util.completes;
-var kCallback = util.kCallback;
+const completes = util.completes;
+const kCallback = util.kCallback;
 
-var LOG_ERRORS = process.env.LOG_ERRORS;
+const LOG_ERRORS = process.env.LOG_ERRORS;
 
-var OPEN_OPTS = {
+const OPEN_OPTS = {
   // start-ok
   clientProperties: {},
   mechanism: 'PLAIN',
@@ -56,14 +56,14 @@ module.exports.connection_handshake = happy_open;
 
 function connectionTest(client, server) {
   return function (done) {
-    var bothDone = latch(2, done);
-    var pair = util.socketPair();
-    var c = new Connection(pair.client);
+    const bothDone = latch(2, done);
+    const pair = util.socketPair();
+    const c = new Connection(pair.client);
     if (LOG_ERRORS) c.on('error', console.warn);
     client(c, bothDone);
 
     // NB only not a race here because the writes are synchronous
-    var protocolHeader = pair.server.read(8);
+    const protocolHeader = pair.server.read(8);
     assert.deepEqual(Buffer.from('AMQP' + String.fromCharCode(0, 0, 9, 1)), protocolHeader);
 
     util.runServer(pair.server, function (send, wait) {
@@ -77,8 +77,8 @@ suite('Connection errors', function () {
     // RabbitMQ itself will take at least 3 seconds to close the socket
     // in the event of a handshake problem. Instead of using a live
     // connection, I'm just going to pretend.
-    var pair = util.socketPair();
-    var conn = new Connection(pair.client);
+    const pair = util.socketPair();
+    const conn = new Connection(pair.client);
     pair.server.on('readable', function () {
       pair.server.end();
     });
@@ -86,8 +86,8 @@ suite('Connection errors', function () {
   });
 
   test('bad frame during open', function (done) {
-    var ss = util.socketPair();
-    var conn = new (require('../lib/connection').Connection)(ss.client);
+    const ss = util.socketPair();
+    const conn = new (require('../lib/connection').Connection)(ss.client);
     ss.server.on('readable', function () {
       ss.server.write(Buffer.from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]));
     });
@@ -200,7 +200,7 @@ suite('Connection running', function () {
     'unexpected socket close',
     connectionTest(
       function (c, done) {
-        var errorAndClosed = latch(2, done);
+        const errorAndClosed = latch(2, done);
         c.on('error', succeed(errorAndClosed));
         c.on('close', succeed(errorAndClosed));
         c.open(
@@ -261,7 +261,7 @@ suite('Connection close', function () {
     'happy',
     connectionTest(
       function (c, done0) {
-        var done = latch(2, done0);
+        const done = latch(2, done0);
         c.on('close', done);
         c.open(
           OPEN_OPTS,
@@ -288,7 +288,7 @@ suite('Connection close', function () {
     'interleaved close frames',
     connectionTest(
       function (c, done0) {
-        var done = latch(2, done0);
+        const done = latch(2, done0);
         c.on('close', done);
         c.open(
           OPEN_OPTS,
@@ -321,7 +321,7 @@ suite('Connection close', function () {
     'server error close',
     connectionTest(
       function (c, done0) {
-        var done = latch(2, done0);
+        const done = latch(2, done0);
         c.on('close', succeed(done));
         c.on('error', succeed(done));
         c.open(OPEN_OPTS);
@@ -395,7 +395,7 @@ suite('Connection close', function () {
 });
 
 suite('heartbeats', function () {
-  var heartbeat = require('../lib/heartbeat');
+  const heartbeat = require('../lib/heartbeat');
 
   setup(function () {
     heartbeat.UNITS_TO_MS = 20;
@@ -410,7 +410,7 @@ suite('heartbeats', function () {
     connectionTest(
       function (c, done) {
         completes(function () {
-          var opts = Object.create(OPEN_OPTS);
+          const opts = Object.create(OPEN_OPTS);
           opts.heartbeat = 1;
           // Don't leave the error waiting to happen for the next test, this
           // confuses mocha awfully
@@ -419,7 +419,7 @@ suite('heartbeats', function () {
         }, done);
       },
       function (send, wait, done, socket) {
-        var timer;
+        let timer;
         happy_open(send, wait)
           .then(function () {
             timer = setInterval(function () {
@@ -440,7 +440,7 @@ suite('heartbeats', function () {
     'detect lack of heartbeats',
     connectionTest(
       function (c, done) {
-        var opts = Object.create(OPEN_OPTS);
+        const opts = Object.create(OPEN_OPTS);
         opts.heartbeat = 1;
         c.on('error', succeed(done));
         c.open(opts);

--- a/test/data.js
+++ b/test/data.js
@@ -2,18 +2,18 @@
 
 'use strict';
 
-var C = require('claire');
-var forAll = C.forAll;
-var arb = C.data;
-var transform = C.transform;
-var repeat = C.repeat;
-var label = C.label;
-var sequence = C.sequence;
-var asGenerator = C.asGenerator;
-var sized = C.sized;
-var recursive = C.recursive;
-var choice = C.choice;
-var Undefined = C.Undefined;
+const C = require('claire');
+const forAll = C.forAll;
+const arb = C.data;
+const transform = C.transform;
+const repeat = C.repeat;
+const label = C.label;
+const sequence = C.sequence;
+const asGenerator = C.asGenerator;
+const sized = C.sized;
+const recursive = C.recursive;
+const choice = C.choice;
+const Undefined = C.Undefined;
 
 // Stub these out so we can use outside tests
 // if (!suite) var suite = function() {}
@@ -39,17 +39,17 @@ function rangeInt(name, a, b) {
 }
 
 function toFloat32(i) {
-  var b = Buffer.alloc(4);
+  const b = Buffer.alloc(4);
   b.writeFloatBE(i, 0);
   return b.readFloatBE(0);
 }
 
 function floatChooser(maxExp) {
   return function () {
-    var n = Number.NaN;
+    let n = Number.NaN;
     while (isNaN(n)) {
-      var mantissa = Math.random() * 2 - 1;
-      var exponent = chooseInt(0, maxExp);
+      const mantissa = Math.random() * 2 - 1;
+      const exponent = chooseInt(0, maxExp);
       n = Math.pow(mantissa, exponent);
     }
     return n;
@@ -67,37 +67,37 @@ function explicitType(t, underlying) {
 
 // FIXME null, byte array, others?
 
-var Octet = rangeInt('octet', 0, 255);
-var ShortStr = label(
+const Octet = rangeInt('octet', 0, 255);
+const ShortStr = label(
   'shortstr',
   transform(function (s) {
     return s.substr(0, 255);
   }, arb.Str),
 );
 
-var LongStr = label(
+const LongStr = label(
   'longstr',
   transform(function (bytes) {
     return Buffer.from(bytes);
   }, repeat(Octet)),
 );
 
-var UShort = rangeInt('short-uint', 0, 0xffff);
-var ULong = rangeInt('long-uint', 0, 0xffffffff);
-var ULongLong = rangeInt('longlong-uint', 0, 0xffffffffffffffff);
-var Short = rangeInt('short-int', -0x8000, 0x7fff);
-var Long = rangeInt('long-int', -0x80000000, 0x7fffffff);
-var LongLong = rangeInt('longlong-int', -0x8000000000000000, 0x7fffffffffffffff);
-var Bit = label('bit', arb.Bool);
-var Double = label('double', asGenerator(floatChooser(308)));
-var Float = label('float', transform(toFloat32, floatChooser(38)));
-var Timestamp = label(
+const UShort = rangeInt('short-uint', 0, 0xffff);
+const ULong = rangeInt('long-uint', 0, 0xffffffff);
+const ULongLong = rangeInt('longlong-uint', 0, 0xffffffffffffffff);
+const Short = rangeInt('short-int', -0x8000, 0x7fff);
+const Long = rangeInt('long-int', -0x80000000, 0x7fffffff);
+const LongLong = rangeInt('longlong-int', -0x8000000000000000, 0x7fffffffffffffff);
+const Bit = label('bit', arb.Bool);
+const Double = label('double', asGenerator(floatChooser(308)));
+const Float = label('float', transform(toFloat32, floatChooser(38)));
+const Timestamp = label(
   'timestamp',
   transform(function (n) {
     return {'!': 'timestamp', value: n};
   }, ULongLong),
 );
-var Decimal = label(
+const Decimal = label(
   'decimal',
   transform(
     function (args) {
@@ -106,19 +106,19 @@ var Decimal = label(
     sequence(arb.UInt, Octet),
   ),
 );
-var UnsignedByte = label(
+const UnsignedByte = label(
   'unsignedbyte',
   transform(function (n) {
     return {'!': 'unsignedbyte', value: n};
   }, Octet),
 );
-var UnsignedShort = label(
+const UnsignedShort = label(
   'unsignedshort',
   transform(function (n) {
     return {'!': 'unsignedshort', value: n};
   }, UShort),
 );
-var UnsignedInt = label(
+const UnsignedInt = label(
   'unsignedint',
   transform(function (n) {
     return {'!': 'unsignedint', value: n};
@@ -126,19 +126,19 @@ var UnsignedInt = label(
 );
 
 // Signed 8 bit int
-var Byte = rangeInt('byte', -128, 127);
+const Byte = rangeInt('byte', -128, 127);
 
 // Explicitly typed values
-var ExByte = explicitType('byte', Byte);
-var ExInt8 = explicitType('int8', Byte);
-var ExShort = explicitType('short', Short);
-var ExInt16 = explicitType('int16', Short);
-var ExInt = explicitType('int', Long);
-var ExInt32 = explicitType('int32', Long);
-var ExLong = explicitType('long', LongLong);
-var ExInt64 = explicitType('int64', LongLong);
+const ExByte = explicitType('byte', Byte);
+const ExInt8 = explicitType('int8', Byte);
+const ExShort = explicitType('short', Short);
+const ExInt16 = explicitType('int16', Short);
+const ExInt = explicitType('int', Long);
+const ExInt32 = explicitType('int32', Long);
+const ExLong = explicitType('long', LongLong);
+const ExInt64 = explicitType('int64', LongLong);
 
-var FieldArray = label(
+const FieldArray = label(
   'field-array',
   recursive(function () {
     return arb.Array(
@@ -170,7 +170,7 @@ var FieldArray = label(
   }),
 );
 
-var FieldTable = label(
+const FieldTable = label(
   'table',
   recursive(function () {
     return sized(
@@ -208,7 +208,7 @@ var FieldTable = label(
 );
 
 // Internal tests of our properties
-var domainProps = [
+const domainProps = [
   [
     Octet,
     function (n) {
@@ -315,10 +315,10 @@ suite('Domains', function () {
 
 // For methods and properties (as opposed to field table values) it's
 // easier just to accept and produce numbers for timestamps.
-var ArgTimestamp = label('timestamp', ULongLong);
+const ArgTimestamp = label('timestamp', ULongLong);
 
 // These are the domains used in method arguments
-var ARG_TYPES = {
+const ARG_TYPES = {
   octet: Octet,
   shortstr: ShortStr,
   longstr: LongStr,
@@ -339,7 +339,7 @@ function argtype(thing) {
 }
 
 function zipObject(vals, names) {
-  var obj = {};
+  const obj = {};
   vals.forEach(function (v, i) {
     obj[names[i]] = v;
   });
@@ -350,11 +350,11 @@ function name(arg) {
   return arg.name;
 }
 
-var defs = require('../lib/defs');
+const defs = require('../lib/defs');
 
 function method(info) {
-  var domain = sequence.apply(null, info.args.map(argtype));
-  var names = info.args.map(name);
+  const domain = sequence.apply(null, info.args.map(argtype));
+  const names = info.args.map(name);
   return label(
     info.name,
     transform(function (fieldVals) {
@@ -364,10 +364,10 @@ function method(info) {
 }
 
 function properties(info) {
-  var types = info.args.map(argtype);
+  const types = info.args.map(argtype);
   types.unshift(ULongLong); // size
-  var domain = sequence.apply(null, types);
-  var names = info.args.map(name);
+  const domain = sequence.apply(null, types);
+  const names = info.args.map(name);
   return label(
     info.name,
     transform(function (fieldVals) {
@@ -376,10 +376,10 @@ function properties(info) {
   );
 }
 
-var methods = [];
-var propertieses = [];
+const methods = [];
+const propertieses = [];
 
-for (var k in defs) {
+for (const k in defs) {
   if (k.substr(0, 10) === 'methodInfo') {
     methods.push(method(defs[k]));
     methods[defs[k].name] = method(defs[k]);

--- a/test/frame.js
+++ b/test/frame.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var assert = require('assert');
-var connection = require('../lib/connection');
-var Frames = connection.Connection;
-var HEARTBEAT = require('../lib/frame').HEARTBEAT;
-var Stream = require('stream');
-var PassThrough = Stream.PassThrough;
+const assert = require('assert');
+const connection = require('../lib/connection');
+const Frames = connection.Connection;
+const HEARTBEAT = require('../lib/frame').HEARTBEAT;
+const Stream = require('stream');
+const PassThrough = Stream.PassThrough;
 
-var defs = require('../lib/defs');
+const defs = require('../lib/defs');
 
 // We'll need to supply a stream which we manipulate ourselves
 
@@ -17,7 +17,7 @@ function inputs() {
   return new PassThrough({objectMode: true});
 }
 
-var HB = Buffer.from([
+const HB = Buffer.from([
   defs.constants.FRAME_HEARTBEAT,
   0,
   0, // channel 0
@@ -30,16 +30,16 @@ var HB = Buffer.from([
 
 suite('Explicit parsing', function () {
   test('Parse heartbeat', function () {
-    var input = inputs();
-    var frames = new Frames(input);
+    const input = inputs();
+    const frames = new Frames(input);
     input.write(HB);
     assert(frames.recvFrame() === HEARTBEAT);
     assert(!frames.recvFrame());
   });
 
   test('Parse partitioned', function () {
-    var input = inputs();
-    var frames = new Frames(input);
+    const input = inputs();
+    const frames = new Frames(input);
     input.write(HB.subarray(0, 3));
     assert(!frames.recvFrame());
     input.write(HB.subarray(3));
@@ -49,8 +49,8 @@ suite('Explicit parsing', function () {
 
   function testBogusFrame(name, bytes) {
     test(name, function (done) {
-      var input = inputs();
-      var frames = new Frames(input);
+      const input = inputs();
+      const frames = new Frames(input);
       frames.frameMax = 5; //for the max frame test
       input.write(Buffer.from(bytes));
       frames.step(function (err, _frame) {
@@ -90,28 +90,28 @@ suite('Explicit parsing', function () {
 
 // Now for a bit more fun.
 
-var amqp = require('./data');
-var claire = require('claire');
-var choice = claire.choice;
-var forAll = claire.forAll;
-var repeat = claire.repeat;
-var label = claire.label;
-var sequence = claire.sequence;
-var transform = claire.transform;
-var sized = claire.sized;
+const amqp = require('./data');
+const claire = require('claire');
+const choice = claire.choice;
+const forAll = claire.forAll;
+const repeat = claire.repeat;
+const label = claire.label;
+const sequence = claire.sequence;
+const transform = claire.transform;
+const sized = claire.sized;
 
-var assertEqualModuloDefaults = require('./codec').assertEqualModuloDefaults;
+const assertEqualModuloDefaults = require('./codec').assertEqualModuloDefaults;
 
-var Trace = label('frame trace', repeat(choice.apply(choice, amqp.methods)));
+const Trace = label('frame trace', repeat(choice.apply(choice, amqp.methods)));
 
 suite('Parsing', function () {
   function testPartitioning(partition) {
     return forAll(Trace)
       .satisfy(function (t) {
-        var bufs = [];
-        var input = inputs();
-        var frames = new Frames(input);
-        var i = 0,
+        const bufs = [];
+        const input = inputs();
+        const frames = new Frames(input);
+        let i = 0,
           ex;
         frames.accept = function (f) {
           // A minor hack to make sure we get the assertion exception;
@@ -157,24 +157,24 @@ suite('Parsing', function () {
   test(
     'Parse partitioned methods',
     testPartitioning(function (bufs) {
-      var full = Buffer.concat(bufs);
-      var onethird = Math.floor(full.length / 3);
-      var twothirds = 2 * onethird;
+      const full = Buffer.concat(bufs);
+      const onethird = Math.floor(full.length / 3);
+      const twothirds = 2 * onethird;
       return [full.subarray(0, onethird), full.subarray(onethird, twothirds), full.subarray(twothirds)];
     }),
   );
 });
 
-var FRAME_MAX_MAX = 4096 * 4;
-var FRAME_MAX_MIN = 4096;
+const FRAME_MAX_MAX = 4096 * 4;
+const FRAME_MAX_MIN = 4096;
 
-var FrameMax = amqp.rangeInt('frame max', FRAME_MAX_MIN, FRAME_MAX_MAX);
+const FrameMax = amqp.rangeInt('frame max', FRAME_MAX_MIN, FRAME_MAX_MAX);
 
-var Body = sized(function (_n) {
+const Body = sized(function (_n) {
   return Math.floor(Math.random() * FRAME_MAX_MAX);
 }, repeat(amqp.Octet));
 
-var Content = transform(
+const Content = transform(
   function (args) {
     return {
       method: args[0].fields,
@@ -190,11 +190,11 @@ suite('Content framing', function () {
     'Adhere to frame max',
     forAll(Content, FrameMax)
       .satisfy(function (content, max) {
-        var input = inputs();
-        var frames = new Frames(input);
+        const input = inputs();
+        const frames = new Frames(input);
         frames.frameMax = max;
         frames.sendMessage(0, defs.BasicDeliver, content.method, defs.BasicProperties, content.header, content.body);
-        var f,
+        let f,
           _i = 0,
           largest = 0;
         while ((f = input.read())) {

--- a/test/mux.js
+++ b/test/mux.js
@@ -1,21 +1,21 @@
 'use strict';
 
-var assert = require('assert');
-var Mux = require('../lib/mux').Mux;
-var PassThrough = require('stream').PassThrough;
+const assert = require('assert');
+const Mux = require('../lib/mux').Mux;
+const PassThrough = require('stream').PassThrough;
 
-var latch = require('./util').latch;
-var schedule = require('./util').schedule;
+const latch = require('./util').latch;
+const schedule = require('./util').schedule;
 
 function stream() {
   return new PassThrough({objectMode: true});
 }
 
 function readAllObjects(s, cb) {
-  var objs = [];
+  const objs = [];
 
   function read() {
-    var v = s.read();
+    let v = s.read();
     while (v !== null) {
       objs.push(v);
       v = s.read();
@@ -31,16 +31,16 @@ function readAllObjects(s, cb) {
 }
 
 test('single input', function (done) {
-  var input = stream();
-  var output = stream();
+  const input = stream();
+  const output = stream();
   input.on('end', function () {
     output.end();
   });
 
-  var mux = new Mux(output);
+  const mux = new Mux(output);
   mux.pipeFrom(input);
 
-  var data = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+  const data = [1, 2, 3, 4, 5, 6, 7, 8, 9];
   // not 0, it's treated specially by PassThrough for some reason. By
   // 'specially' I mean it breaks the stream. See e.g.,
   // https://github.com/isaacs/readable-stream/pull/55
@@ -57,22 +57,22 @@ test('single input', function (done) {
 });
 
 test('single input, resuming stream', function (done) {
-  var input = stream();
-  var output = stream();
+  const input = stream();
+  const output = stream();
   input.on('end', function () {
     output.end();
   });
 
-  var mux = new Mux(output);
+  const mux = new Mux(output);
   mux.pipeFrom(input);
 
   // Streams might be blocked and become readable again, simulate this
   // using a special read function and a marker
-  var data = [1, 2, 3, 4, 'skip', 6, 7, 8, 9];
+  const data = [1, 2, 3, 4, 'skip', 6, 7, 8, 9];
 
-  var oldRead = input.read;
+  const oldRead = input.read;
   input.read = function (size) {
-    var val = oldRead.call(input, size);
+    const val = oldRead.call(input, size);
 
     if (val === 'skip') {
       input.emit('readable');
@@ -95,14 +95,14 @@ test('single input, resuming stream', function (done) {
 });
 
 test('two sequential inputs', function (done) {
-  var input1 = stream();
-  var input2 = stream();
-  var output = stream();
-  var mux = new Mux(output);
+  const input1 = stream();
+  const input2 = stream();
+  const output = stream();
+  const mux = new Mux(output);
   mux.pipeFrom(input1);
   mux.pipeFrom(input2);
 
-  var data = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+  const data = [1, 2, 3, 4, 5, 6, 7, 8, 9];
   data.forEach(function (v) {
     input1.write(v);
   });
@@ -125,20 +125,20 @@ test('two sequential inputs', function (done) {
 });
 
 test('two interleaved inputs', function (done) {
-  var input1 = stream();
-  var input2 = stream();
-  var output = stream();
-  var mux = new Mux(output);
+  const input1 = stream();
+  const input2 = stream();
+  const output = stream();
+  const mux = new Mux(output);
   mux.pipeFrom(input1);
   mux.pipeFrom(input2);
 
-  var endLatch = latch(2, function () {
+  const endLatch = latch(2, function () {
     output.end();
   });
   input1.on('end', endLatch);
   input2.on('end', endLatch);
 
-  var data = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+  const data = [1, 2, 3, 4, 5, 6, 7, 8, 9];
   data.forEach(function (v) {
     input1.write(v);
   });
@@ -156,12 +156,12 @@ test('two interleaved inputs', function (done) {
 });
 
 test('unpipe', function (done) {
-  var input = stream();
-  var output = stream();
-  var mux = new Mux(output);
+  const input = stream();
+  const output = stream();
+  const mux = new Mux(output);
 
-  var pipedData = [1, 2, 3, 4, 5];
-  var unpipedData = [6, 7, 8, 9];
+  const pipedData = [1, 2, 3, 4, 5];
+  const unpipedData = [6, 7, 8, 9];
 
   mux.pipeFrom(input);
 
@@ -180,7 +180,7 @@ test('unpipe', function (done) {
         input.end();
         schedule(function () {
           // exhaust so that 'end' fires
-          var v;
+          let v;
           while ((v = input.read()));
         });
       });
@@ -202,27 +202,27 @@ test('unpipe', function (done) {
 });
 
 test('roundrobin', function (done) {
-  var input1 = stream();
-  var input2 = stream();
-  var output = stream();
-  var mux = new Mux(output);
+  const input1 = stream();
+  const input2 = stream();
+  const output = stream();
+  const mux = new Mux(output);
 
   mux.pipeFrom(input1);
   mux.pipeFrom(input2);
 
-  var endLatch = latch(2, function () {
+  const endLatch = latch(2, function () {
     output.end();
   });
   input1.on('end', endLatch);
   input2.on('end', endLatch);
 
-  var ones = [1, 1, 1, 1, 1];
+  const ones = [1, 1, 1, 1, 1];
   ones.forEach(function (v) {
     input1.write(v);
   });
   input1.end();
 
-  var twos = [2, 2, 2, 2, 2];
+  const twos = [2, 2, 2, 2, 2];
   twos.forEach(function (v) {
     input2.write(v);
   });

--- a/test/util.js
+++ b/test/util.js
@@ -1,15 +1,15 @@
 'use strict';
 
-var crypto = require('crypto');
-var Connection = require('../lib/connection').Connection;
-var PassThrough = require('stream').PassThrough;
-var defs = require('../lib/defs');
-var assert = require('assert');
+const crypto = require('crypto');
+const Connection = require('../lib/connection').Connection;
+const PassThrough = require('stream').PassThrough;
+const defs = require('../lib/defs');
+const assert = require('assert');
 
-var schedule = typeof setImmediate === 'function' ? setImmediate : process.nextTick;
+const schedule = typeof setImmediate === 'function' ? setImmediate : process.nextTick;
 
 function randomString() {
-  var hash = crypto.createHash('sha1');
+  const hash = crypto.createHash('sha1');
   hash.update(crypto.randomBytes(64));
   return hash.digest('base64');
 }
@@ -31,8 +31,8 @@ function randomString() {
 // the other.
 
 function socketPair() {
-  var server = new PassThrough();
-  var client = new PassThrough();
+  const server = new PassThrough();
+  const client = new PassThrough();
   server.write = client.push.bind(client);
   client.write = server.push.bind(server);
   function end(chunk, encoding) {
@@ -46,7 +46,7 @@ function socketPair() {
 }
 
 function runServer(socket, run) {
-  var frames = new Connection(socket);
+  const frames = new Connection(socket);
   // We will be closing the socket without doing a closing handshake,
   // so cheat
   frames.expectSocketClose = true;
@@ -124,8 +124,8 @@ function fail(done) {
 // `count` times. If it's called with an error value, it will
 // immediately call done with that error value.
 function latch(count, done) {
-  var awaiting = count;
-  var alive = true;
+  let awaiting = count;
+  let alive = true;
   return function (err) {
     if (err instanceof Error && alive) {
       alive = false;
@@ -166,10 +166,10 @@ function versionGreaterThan(actual, spec) {
     return parseInt(e);
   }
 
-  var version = actual.split('.').map(int);
-  var desired = spec.split('.').map(int);
-  for (var i = 0; i < desired.length; i++) {
-    var a = version[i],
+  const version = actual.split('.').map(int);
+  const desired = spec.split('.').map(int);
+  for (let i = 0; i < desired.length; i++) {
+    const a = version[i],
       b = desired[i];
     if (a != b) return a > b;
   }


### PR DESCRIPTION
Killed 3 birds (noVar, noInnerDeclarations, noInvalidUseBeforeDeclaration) with one stone 
- Replace 674 var declarations with appropriate let/const
- Use const for immutable values (requires, constants, never-reassigned variables)
- Use let for variables that get reassigned (loop counters, mutated state)
- Modernise codebase for Node.js v18+ with proper block scoping
- Eliminate variable hoisting issues and improve code clarity
- All tests pass with zero linting errors

🤖 Generated with [Claude Code](https://claude.ai/code)