### PR TITLE
Use modern exponentiation operator instead of Math.pow()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Add block scoping to switch statement cases to prevent variable declaration issues
 - Enforce const usage for variables that are never reassigned
 - Add node: protocol prefix to Node.js builtin module imports for clarity
+- Use modern exponentiation operator (**) instead of Math.pow()
 
 ## v0.10.9
 - Add support for IPv6 urls

--- a/biome.json
+++ b/biome.json
@@ -20,8 +20,7 @@
         "useLiteralKeys": "off"
       },
       "style": {
-        "useTemplate": "off",
-        "useExponentiationOperator": "off"
+        "useTemplate": "off"
       },
       "suspicious": {
         "noRedundantUseStrict": "off",

--- a/test/data.js
+++ b/test/data.js
@@ -50,7 +50,7 @@ function floatChooser(maxExp) {
     while (isNaN(n)) {
       const mantissa = Math.random() * 2 - 1;
       const exponent = chooseInt(0, maxExp);
-      n = Math.pow(mantissa, exponent);
+      n = mantissa ** exponent;
     }
     return n;
   };


### PR DESCRIPTION
- Replace Math.pow() with ** operator in test/data.js
- Remove explicit useExponentiationOperator config as it's enabled by default
- Update changelog with exponentiation operator entry
- Improves readability with modern JavaScript syntax

🤖 Generated with [Claude Code](https://claude.ai/code)