### PR TITLE
Modernisation 14 - no assign in expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Use modern exponentiation operator (**) instead of Math.pow()
 - Replace string concatenation with modern template literals
 - Remove redundant 'use strict' directives as modules are automatically in strict mode
+- Refactor assignment-in-expression patterns to improve code clarity and readability
 
 ## v0.10.9
 - Add support for IPv6 urls

--- a/biome.json
+++ b/biome.json
@@ -21,7 +21,6 @@
       },
       "suspicious": {
         "noRedundantUseStrict": "error",
-        "noAssignInExpressions": "off",
         "noAsyncPromiseExecutor": "off",
         "noDoubleEquals": "off",
         "noGlobalIsNan": "off",

--- a/lib/channel.js
+++ b/lib/channel.js
@@ -33,9 +33,10 @@ class Channel extends EventEmitter {
       }),
     );
     this.on('close', function () {
-      let cb;
-      while ((cb = this.unconfirmed.shift())) {
+      let cb = this.unconfirmed.shift();
+      while (cb) {
         if (cb) cb(new Error('channel closed'));
+        cb = this.unconfirmed.shift();
       }
     });
     // message frame state machine
@@ -162,14 +163,17 @@ class Channel extends EventEmitter {
   }
 
   _rejectPending() {
-    function rej(r) {
+    function reject(r) {
       r(new Error('Channel ended, no reply will be forthcoming'));
     }
-    if (this.reply !== null) rej(this.reply);
+    if (this.reply !== null) reject(this.reply);
     this.reply = null;
 
-    let discard;
-    while ((discard = this.pending.shift())) rej(discard.reply);
+    let discard = this.pending.shift();
+    while (discard) {
+      if (discard) reject(discard.reply);
+      discard = this.pending.shift();
+    }
     this.pending = null; // so pushes will break
   }
 

--- a/lib/channel_model.js
+++ b/lib/channel_model.js
@@ -249,9 +249,10 @@ class ConfirmChannel extends Channel {
     });
     // Channel closed
     if (!this.pending) {
-      let cb;
-      while ((cb = this.unconfirmed.shift())) {
+      let cb = this.unconfirmed.shift();
+      while (cb) {
         if (cb) cb(new Error('channel closed'));
+        cb = this.unconfirmed.shift();
       }
     }
     return Promise.all(awaiting);

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -31,8 +31,8 @@ class Connection extends EventEmitter {
   constructor(underlying) {
     super();
 
-    const stream = (this.stream = wrapStream(underlying));
-    this.muxer = new Mux(stream);
+    this.stream = wrapStream(underlying);
+    this.muxer = new Mux(this.stream);
 
     // frames
     this.rest = Buffer.alloc(0);
@@ -406,8 +406,11 @@ class Connection extends EventEmitter {
 
     function go() {
       try {
-        let f;
-        while ((f = self.recvFrame())) self.accept(f);
+        let frame = self.recvFrame();
+        while (frame) {
+          self.accept(frame);
+          frame = self.recvFrame();
+        }
       } catch (e) {
         self.emit('frameError', e);
       }

--- a/lib/mux.js
+++ b/lib/mux.js
@@ -41,13 +41,14 @@ class Mux {
     // Try to read a chunk from each stream in turn, until all streams
     // are empty, or we exhaust our ability to accept chunks.
     function roundrobin(streams) {
-      let s;
-      while (accepting && (s = streams.shift())) {
-        const chunk = s.read();
+      let stream = streams.shift();
+      while (accepting && stream) {
+        const chunk = stream.read();
         if (chunk !== null) {
           accepting = out.write(chunk);
-          streams.push(s);
+          streams.push(stream);
         }
+        stream = streams.shift();
       }
     }
 

--- a/test/frame.js
+++ b/test/frame.js
@@ -192,15 +192,16 @@ suite('Content framing', function () {
         const frames = new Frames(input);
         frames.frameMax = max;
         frames.sendMessage(0, defs.BasicDeliver, content.method, defs.BasicProperties, content.header, content.body);
-        let f,
-          _i = 0,
-          largest = 0;
-        while ((f = input.read())) {
+        let _i = 0;
+        let largest = 0;
+        let frame = input.read();
+        while (frame) {
           _i++;
-          if (f.length > largest) largest = f.length;
-          if (f.length > max) {
+          if (frame.length > largest) largest = frame.length;
+          if (frame.length > max) {
             return false;
           }
+          frame = input.read();
         }
         // The ratio of frames to 'contents' should always be >= 2
         // (one properties frame and at least one content frame); > 2

--- a/test/mux.js
+++ b/test/mux.js
@@ -179,7 +179,9 @@ test('unpipe', function (done) {
         schedule(function () {
           // exhaust so that 'end' fires
           let v;
-          while ((v = input.read()));
+          do {
+            v = input.read();
+          } while (v);
         });
       });
     });


### PR DESCRIPTION
Remove assignments from conditional expressions to improve code clarity and readability. Patterns like while((x = y)) have been refactored to separate assignment from conditional logic using do...while loops or explicit assignments.

🤖 Generated with [Claude Code](https://claude.ai/code)