### PR TITLE
Enforce strict equality checks (=== and !==)

### DIFF
--- a/.claude/commands/lint-enforce.md
+++ b/.claude/commands/lint-enforce.md
@@ -2,12 +2,11 @@ Please follow the following process when I ask you to enfore a new lint rule usi
 
 1. Create and change to a new branch. Ask for the branch name.
 2. Configure the rule to error in biome.json
-3. Run lint (npm run lint). If there are NO errors, goto step 9
-4. If there are no errors goto X
-5. Use biome to SAFELY auto fix (npm run lint -- --fix). If there are errors stop and ask for instruction.
-7. Run the tests (npm test). If there are errors, stop and ask for instruction.
-8. If the rule defaults to error, delete it (See https://biomejs.dev/linter/javascript/rules/ for rule details)
-9. Update the project changelog
-10. Add the changes
-11. Commit the changes
-12. Push the changes
+3. Run lint (npm run lint). If there are NO errors, goto step 8
+4. Use biome to SAFELY auto fix (npm run lint -- --fix). If there are errors stop and ask for instruction.
+5. Run the tests (npm test). If there are errors, stop and ask for instruction.
+6. If the rule defaults to error, delete it (See https://biomejs.dev/linter/javascript/rules/ for rule details)
+7. Update the project changelog
+8. Add the changes
+9. Commit the changes
+10. Push the changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Replace string concatenation with modern template literals
 - Remove redundant 'use strict' directives as modules are automatically in strict mode
 - Refactor assignment-in-expression patterns to improve code clarity and readability
+- Enforce strict equality checks (=== and !==) instead of loose equality (== and !=)
 
 ## v0.10.9
 - Add support for IPv6 urls

--- a/bin/generate-defs.js
+++ b/bin/generate-defs.js
@@ -330,7 +330,7 @@ function encoderFn(method) {
   for (let i = 0, len = args.length; i < len; i++) {
     const arg = args[i];
 
-    if (arg.type != 'bit') bitsInARow = 0;
+    if (arg.type !== 'bit') bitsInARow = 0;
 
     switch (arg.type) {
       // varying size
@@ -391,7 +391,7 @@ function encoderFn(method) {
     const a = args[i];
 
     // Flush any collected bits before doing a new field
-    if (a.type != 'bit' && bitsInARow > 0) {
+    if (a.type !== 'bit' && bitsInARow > 0) {
       bitsInARow = 0;
       println('buffer[offset] = bits; offset++; bits = 0;');
     }
@@ -476,7 +476,7 @@ function decoderFn(method) {
     const field = `fields['${a.name}']`;
 
     // Flush any collected bits before doing a new field
-    if (a.type != 'bit' && bitsInARow > 0) {
+    if (a.type !== 'bit' && bitsInARow > 0) {
       bitsInARow = 0;
       println('offset++;');
     }

--- a/biome.json
+++ b/biome.json
@@ -22,7 +22,6 @@
       "suspicious": {
         "noRedundantUseStrict": "error",
         "noAsyncPromiseExecutor": "off",
-        "noDoubleEquals": "off",
         "noGlobalIsNan": "off",
         "noRedeclare": "off",
         "noGlobalIsFinite": "off",

--- a/lib/api_args.js
+++ b/lib/api_args.js
@@ -32,7 +32,7 @@ fields for handing to the encoder.
 // NB the `arguments` field already has a default value of `{}`, so
 // there's no need to explicitly default it unless I'm setting values.
 function setIfDefined(obj, prop, value) {
-  if (value != undefined) obj[prop] = value;
+  if (value !== undefined) obj[prop] = value;
 }
 
 const EMPTY_OPTIONS = Object.freeze({});

--- a/lib/bitset.js
+++ b/lib/bitset.js
@@ -91,7 +91,7 @@ class BitSet {
     while (true) {
       if (word) return w * 32 + trailingZeros(word);
       w++;
-      if (w == this.wordsInUse) return w * 32;
+      if (w === this.wordsInUse) return w * 32;
       word = ~this.words[w];
     }
   }
@@ -115,22 +115,22 @@ function trailingZeros(i) {
   let y,
     n = 31;
   y = i << 16;
-  if (y != 0) {
+  if (y !== 0) {
     n = n - 16;
     i = y;
   }
   y = i << 8;
-  if (y != 0) {
+  if (y !== 0) {
     n = n - 8;
     i = y;
   }
   y = i << 4;
-  if (y != 0) {
+  if (y !== 0) {
     n = n - 4;
     i = y;
   }
   y = i << 2;
-  if (y != 0) {
+  if (y !== 0) {
     n = n - 2;
     i = y;
   }

--- a/lib/codec.js
+++ b/lib/codec.js
@@ -58,7 +58,7 @@ function encodeFieldValue(buffer, value, offset) {
 
   // If it's a JS number, we'll have to guess what type to encode it
   // as.
-  if (type == 'number') {
+  if (type === 'number') {
     // Making assumptions about the kind of number (floating point
     // v integer, signed, unsigned, size) desired is dangerous in
     // general; however, in practice RabbitMQ uses only
@@ -284,7 +284,7 @@ function decodeFields(slice) {
         offset += 2;
         break;
       case 't':
-        val = slice[offset] != 0;
+        val = slice[offset] !== 0;
         offset++;
         break;
       case 'V':

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -70,7 +70,7 @@ function openFrames(vhost, query, credentials, extraClientProperties) {
 function credentialsFromUrl(parts) {
   let user = 'guest',
     passwd = 'guest';
-  if (parts.username != '' || parts.password != '') {
+  if (parts.username !== '' || parts.password !== '') {
     user = parts.username ? unescape(parts.username) : '';
     passwd = parts.password ? unescape(parts.password) : '';
   }
@@ -103,7 +103,7 @@ function connect(url, socketOptions, openCallback) {
     let user, pass;
     // Only default if both are missing, to have the same behaviour as
     // the stringly URL.
-    if (url.username == undefined && url.password == undefined) {
+    if (url.username === undefined && url.password === undefined) {
       user = 'guest';
       pass = 'guest';
     } else {

--- a/test/callback_api.js
+++ b/test/callback_api.js
@@ -24,11 +24,11 @@ function ignore() {}
 
 function twice(done) {
   let first = function (err) {
-    if (err == undefined) second = done;
+    if (err === undefined) second = done;
     else (second = ignore), done(err);
   };
   let second = function (err) {
-    if (err == undefined) first = done;
+    if (err === undefined) first = done;
     else (first = ignore), done(err);
   };
   return {
@@ -196,7 +196,7 @@ suite('sending messages', function () {
       ch.consume(
         q.queue,
         function (m) {
-          if (m.content.toString() == msg) done();
+          if (m.content.toString() === msg) done();
           else done(new Error(`message content doesn't match:${msg} =/= ${m.content.toString()}`));
         },
         {noAck: true, exclusive: true},
@@ -212,7 +212,7 @@ suite('sending messages', function () {
       ch.consume(
         q.queue,
         function (m) {
-          if (m.content.toString() == msg) {
+          if (m.content.toString() === msg) {
             ch.ack(m);
             done();
           } else done(new Error(`message content doesn't match:${msg} =/= ${m.content.toString()}`));
@@ -233,7 +233,7 @@ suite('sending messages', function () {
         ch.get(q.queue, {noAck: true}, function (e, m) {
           if (e != null) return done(e);
           else if (!m) return done(new Error('Empty (false) not expected'));
-          else if (m.content.toString() == msg) return done();
+          else if (m.content.toString() === msg) return done();
           else return done(new Error(`Messages do not match: ${msg} =/= ${m.content.toString()}`));
         });
       });

--- a/test/connect.js
+++ b/test/connect.js
@@ -17,10 +17,10 @@ const urlparse = require('url-parse');
 
 suite('Credentials', function () {
   function checkCreds(creds, user, pass, done) {
-    if (creds.mechanism != 'PLAIN') {
+    if (creds.mechanism !== 'PLAIN') {
       return done('expected mechanism PLAIN');
     }
-    if (creds.username != user || creds.password != pass) {
+    if (creds.username !== user || creds.password !== pass) {
       return done(format("expected '%s', '%s'; got '%s', '%s'", user, pass, creds.username, creds.password));
     }
     done();

--- a/test/util.js
+++ b/test/util.js
@@ -169,7 +169,7 @@ function versionGreaterThan(actual, spec) {
   for (let i = 0; i < desired.length; i++) {
     const a = version[i],
       b = desired[i];
-    if (a != b) return a > b;
+    if (a !== b) return a > b;
   }
   return false;
 }


### PR DESCRIPTION
Replace all instances of loose equality (== and !=) with strict equality operators to prevent type coercion bugs and improve code reliability.

🤖 Generated with [Claude Code](https://claude.ai/code)