### PR TITLE
Modernisation 17 - Ensure no variable redeclarations exist to prevent shadowing issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Refactor assignment-in-expression patterns to improve code clarity and readability
 - Enforce strict equality checks (=== and !==) instead of loose equality (== and !=)
 - Replace global isNaN with Number.isNaN for safer type checking
+- Ensure no variable redeclarations exist to prevent shadowing issues
 
 ## v0.10.9
 - Add support for IPv6 urls

--- a/biome.json
+++ b/biome.json
@@ -23,7 +23,6 @@
         "noRedundantUseStrict": "error",
         "noAsyncPromiseExecutor": "off",
         "noGlobalIsNan": "error",
-        "noRedeclare": "off",
         "noGlobalIsFinite": "off",
         "noPrototypeBuiltins": "off",
         "noVar": "error"


### PR DESCRIPTION
Enable the noRedeclare lint rule to prevent variable shadowing and maintain code clarity. The codebase already complies with this rule.

🤖 Generated with [Claude Code](https://claude.ai/code)