### PR TITLE
Modernisation 21 - no useless catch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Ensure no variable redeclarations exist to prevent shadowing issues
 - Replace global isFinite with Number.isFinite for safer numeric validation
 - Enable useArrowFunction lint rule to prefer arrow functions for cleaner syntax
+- Remove useless catch clauses that only rethrow errors without handling them
 
 ## v0.10.9
 - Add support for IPv6 urls

--- a/biome.json
+++ b/biome.json
@@ -13,7 +13,7 @@
     "rules": {
       "complexity": {
         "noCommaOperator": "off",
-        "noUselessCatch": "off",
+        "noUselessCatch": "error",
         "useArrowFunction": "error",
         "useOptionalChain": "off",
         "noArguments": "off",

--- a/biome.json
+++ b/biome.json
@@ -42,6 +42,6 @@
     }
   },
   "files": {
-    "includes": ["**/*.js", "!lib/defs.js", "!test"]
+    "includes": ["**/*.js", "!lib/defs.js"]
   }
 }

--- a/examples/receive_generator.js
+++ b/examples/receive_generator.js
@@ -10,19 +10,15 @@ co(function* () {
     }
   };
   const conn = yield amqp.connect('amqp://localhost');
-  try {
-    // create a message to consume
-    const q = 'hello';
-    const msg = 'Hello World!';
-    const channel = yield conn.createChannel();
-    yield channel.assertQueue(q);
-    channel.sendToQueue(q, Buffer.from(msg));
-    console.log(" [x] Sent '%s'", msg);
-    // consume the message
-    yield channel.consume(q, myConsumer, {noAck: true});
-  } catch (e) {
-    throw e;
-  }
+  // create a message to consume
+  const q = 'hello';
+  const msg = 'Hello World!';
+  const channel = yield conn.createChannel();
+  yield channel.assertQueue(q);
+  channel.sendToQueue(q, Buffer.from(msg));
+  console.log(" [x] Sent '%s'", msg);
+  // consume the message
+  yield channel.consume(q, myConsumer, {noAck: true});
 }).catch((err) => {
   console.warn('Error:', err);
 });

--- a/examples/send_generators.js
+++ b/examples/send_generators.js
@@ -9,7 +9,6 @@ co(function* () {
   // connection errors are handled in the co .catch handler
   const conn = yield amqp.connect('amqp://localhost');
 
-  // try catch will throw any errors from the yielding the following promises to the co .catch handler
   try {
     const q = 'hello';
     const msg = 'Hello World!';
@@ -27,8 +26,6 @@ co(function* () {
     console.log(" [x] Sent '%s'", msg);
 
     channel.close();
-  } catch (e) {
-    throw e;
   } finally {
     conn.close();
   }


### PR DESCRIPTION
- Enable noUselessCatch lint rule to error level
- Fix 2 violations in examples/receive_generator.js and examples/send_generators.js
- Remove catch blocks that only rethrow without handling

🤖 Generated with Claude Code