### PR TITLE
Modernisation 22 - noArguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Replace global isFinite with Number.isFinite for safer numeric validation
 - Enable useArrowFunction lint rule to prefer arrow functions for cleaner syntax
 - Remove useless catch clauses that only rethrow errors without handling them
+- Replace arguments object with rest parameters for modern JavaScript best practices
 
 ## v0.10.9
 - Add support for IPv6 urls

--- a/bin/generate-defs.js
+++ b/bin/generate-defs.js
@@ -12,15 +12,15 @@ const PROPERTIES_OVERHEAD = FRAME_OVERHEAD + 4 + 8 + 2;
 
 const out = process.stdout;
 
-function printf() {
-  out.write(format.apply(format, arguments), 'utf8');
+function printf(...args) {
+  out.write(format.apply(format, ...args), 'utf8');
 }
 
 function nl() {
   out.write('\n');
 }
-function println() {
-  printf.apply(printf, arguments);
+function println(...args) {
+  printf.apply(printf, ...args);
   nl();
 }
 

--- a/biome.json
+++ b/biome.json
@@ -16,7 +16,7 @@
         "noUselessCatch": "error",
         "useArrowFunction": "error",
         "useOptionalChain": "off",
-        "noArguments": "off",
+        "noArguments": "error",
         "useLiteralKeys": "off"
       },
       "suspicious": {

--- a/lib/callback_model.js
+++ b/lib/callback_model.js
@@ -22,7 +22,7 @@ class CallbackModel extends EventEmitter {
   }
 
   createChannel(options, cb) {
-    if (arguments.length === 1) {
+    if (typeof options === 'function' && cb === undefined) {
       cb = options;
       options = undefined;
     }
@@ -36,7 +36,7 @@ class CallbackModel extends EventEmitter {
   }
 
   createConfirmChannel(options, cb) {
-    if (arguments.length === 1) {
+    if (typeof options === 'function' && cb === undefined) {
       cb = options;
       options = undefined;
     }


### PR DESCRIPTION
- Enable noArguments lint rule to error level
- Replace arguments usage with rest parameters in printf and println functions
- Replace arguments.length checks with type checking for optional parameters
- Modern JavaScript best practice to avoid the legacy arguments object

🤖 Generated with Claude Code