### PR TITLE
Modernisation 21 - Enable noUselessCatch lint rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Ensure no variable redeclarations exist to prevent shadowing issues
 - Replace global isFinite with Number.isFinite for safer numeric validation
 - Enable useArrowFunction lint rule to prefer arrow functions for cleaner syntax
+- Enable noUselessCatch lint rule to prevent useless catch blocks that only rethrow errors
 
 ## v0.10.9
 - Add support for IPv6 urls

--- a/biome.json
+++ b/biome.json
@@ -13,7 +13,7 @@
     "rules": {
       "complexity": {
         "noCommaOperator": "off",
-        "noUselessCatch": "off",
+        "noUselessCatch": "error",
         "useArrowFunction": "error",
         "useOptionalChain": "off",
         "noArguments": "off",

--- a/examples/receive_generator.js
+++ b/examples/receive_generator.js
@@ -10,19 +10,15 @@ co(function* () {
     }
   };
   const conn = yield amqp.connect('amqp://localhost');
-  try {
-    // create a message to consume
-    const q = 'hello';
-    const msg = 'Hello World!';
-    const channel = yield conn.createChannel();
-    yield channel.assertQueue(q);
-    channel.sendToQueue(q, Buffer.from(msg));
-    console.log(" [x] Sent '%s'", msg);
-    // consume the message
-    yield channel.consume(q, myConsumer, {noAck: true});
-  } catch (e) {
-    throw e;
-  }
+  // create a message to consume
+  const q = 'hello';
+  const msg = 'Hello World!';
+  const channel = yield conn.createChannel();
+  yield channel.assertQueue(q);
+  channel.sendToQueue(q, Buffer.from(msg));
+  console.log(" [x] Sent '%s'", msg);
+  // consume the message
+  yield channel.consume(q, myConsumer, {noAck: true});
 }).catch((err) => {
   console.warn('Error:', err);
 });

--- a/examples/send_generators.js
+++ b/examples/send_generators.js
@@ -27,8 +27,6 @@ co(function* () {
     console.log(" [x] Sent '%s'", msg);
 
     channel.close();
-  } catch (e) {
-    throw e;
   } finally {
     conn.close();
   }


### PR DESCRIPTION
- Configure noUselessCatch rule to error in biome.json to prevent useless catch blocks that only rethrow errors
- Remove useless catch blocks from example files (examples/receive_generator.js and examples/send_generators.js)
- Update CHANGELOG.md with the new lint rule

🤖 Generated with [Claude Code](https://claude.ai/code)