### PR TITLE
Modernisation 22 - Enable noArguments rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Replace global isFinite with Number.isFinite for safer numeric validation
 - Enable useArrowFunction lint rule to prefer arrow functions for cleaner syntax
 - Enable noUselessCatch lint rule to prevent useless catch blocks that only rethrow errors
+- Enable noArguments rule to enforce modern rest parameters instead of legacy arguments object
 
 ## v0.10.9
 - Add support for IPv6 urls

--- a/bin/generate-defs.js
+++ b/bin/generate-defs.js
@@ -12,15 +12,15 @@ const PROPERTIES_OVERHEAD = FRAME_OVERHEAD + 4 + 8 + 2;
 
 const out = process.stdout;
 
-function printf() {
-  out.write(format.apply(format, arguments), 'utf8');
+function printf(...args) {
+  out.write(format.apply(format, args), 'utf8');
 }
 
 function nl() {
   out.write('\n');
 }
-function println() {
-  printf.apply(printf, arguments);
+function println(...args) {
+  printf.apply(printf, args);
   nl();
 }
 

--- a/biome.json
+++ b/biome.json
@@ -16,7 +16,7 @@
         "noUselessCatch": "error",
         "useArrowFunction": "error",
         "useOptionalChain": "off",
-        "noArguments": "off",
+        "noArguments": "error",
         "useLiteralKeys": "off"
       },
       "suspicious": {

--- a/lib/callback_model.js
+++ b/lib/callback_model.js
@@ -22,7 +22,7 @@ class CallbackModel extends EventEmitter {
   }
 
   createChannel(options, cb) {
-    if (arguments.length === 1) {
+    if (cb === undefined) {
       cb = options;
       options = undefined;
     }
@@ -36,7 +36,7 @@ class CallbackModel extends EventEmitter {
   }
 
   createConfirmChannel(options, cb) {
-    if (arguments.length === 1) {
+    if (cb === undefined) {
       cb = options;
       options = undefined;
     }


### PR DESCRIPTION
…legacy arguments object

- Configure noArguments rule as error in biome.json
- Replace arguments object usage with rest parameters in bin/generate-defs.js
- Replace arguments.length checks with parameter validation in lib/callback_model.js
- Update project changelog to document the modernisation

🤖 Generated with [Claude Code](https://claude.ai/code)