### PR TITLE
Enable noCommaOperator lint rule to prevent comma operator usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Replace string concatenation with modern template literals
 - Remove redundant 'use strict' directives as modules are automatically in strict mode
 - Refactor assignment-in-expression patterns to improve code clarity and readability
+- Replace comma operators with individual statements for clearer, more readable code
 - Replace Object.prototype.hasOwnProperty() with safer Object.hasOwn() method
 - Enforce strict equality checks (=== and !==) instead of loose equality (== and !=)
 - Replace global isNaN with Number.isNaN for safer type checking

--- a/biome.json
+++ b/biome.json
@@ -12,7 +12,7 @@
     "enabled": true,
     "rules": {
       "complexity": {
-        "noCommaOperator": "off",
+        "noCommaOperator": "error",
         "noUselessCatch": "error",
         "useArrowFunction": "error",
         "useOptionalChain": "off",

--- a/callback_api.js
+++ b/callback_api.js
@@ -6,8 +6,14 @@ const CallbackModel = require('./lib/callback_model').CallbackModel;
 // connect(url, callback)
 // connect(callback)
 function connect(url, options, cb) {
-  if (typeof url === 'function') (cb = url), (url = false), (options = false);
-  else if (typeof options === 'function') (cb = options), (options = false);
+  if (typeof url === 'function') {
+    cb = url;
+    url = false;
+    options = false;
+  } else if (typeof options === 'function') {
+    cb = options;
+    options = false;
+  }
 
   raw_connect(url, options, (err, c) => {
     if (err === null) cb(null, new CallbackModel(c));

--- a/test/callback_api.js
+++ b/test/callback_api.js
@@ -25,11 +25,17 @@ function ignore() {}
 function twice(done) {
   let first = (err) => {
     if (err === undefined) second = done;
-    else (second = ignore), done(err);
+    else {
+      second = ignore;
+      done(err);
+    }
   };
   let second = (err) => {
     if (err === undefined) first = done;
-    else (first = ignore), done(err);
+    else {
+      first = ignore;
+      done(err);
+    }
   };
   return {
     first: (err) => {

--- a/test/connect.js
+++ b/test/connect.js
@@ -111,7 +111,8 @@ suite('Connect API', () => {
       p = 'guest';
     if (parts.auth) {
       const auth = parts.auth.split(':');
-      (u = auth[0]), (p = auth[1]);
+      u = auth[0];
+      p = auth[1];
     }
     connect(URL, {credentials: require('../lib/credentials').plain(u, p)}, kCallback(succeed(done), fail(done)));
   });
@@ -123,7 +124,8 @@ suite('Connect API', () => {
       p = 'guest';
     if (parts.auth) {
       const auth = parts.auth.split(':');
-      (u = auth[0]), (p = auth[1]);
+      u = auth[0];
+      p = auth[1];
     }
     connect(URL, {credentials: require('../lib/credentials').amqplain(u, p)}, kCallback(succeed(done), fail(done)));
   });


### PR DESCRIPTION
Replace comma operators with individual statements for clearer, more readable code. This improves code maintainability by making side effects more explicit.

🤖 Generated with [Claude Code](https://claude.ai/code)