### PR TITLE
Modernisation 25 - Reformat tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,8 @@
 
 ## v1.0.0
 - **BREAKING**: Update minimum Node.js requirement to v18
-- Introduce Biome formatter for consistent code formatting
-- Add automated formatting via pre-commit hooks using Lefthook
+- Introduce Biome and Lefthook for formatting and linting
 - Format entire codebase with standardised formatting rules
-- Add npm format script for manual code formatting
 - Enable noUnusedFunctionParameters lint rule and fix all violations
 - Enable noUnusedVariables lint rule and remove all unused variables from codebase
 - Replace all var declarations with let/const for modern JavaScript standards

--- a/biome.json
+++ b/biome.json
@@ -35,7 +35,7 @@
   "javascript": {
     "formatter": {
       "arrowParentheses": "always",
-      "bracketSameLine": false,
+      "bracketSameLine": true,
       "bracketSpacing": false,
       "jsxQuoteStyle": "double",
       "quoteProperties": "asNeeded",
@@ -46,5 +46,13 @@
   },
   "files": {
     "includes": ["**/*.js", "!lib/defs.js"]
-  }
+  },
+  "overrides": [
+    {
+      "includes": ["test/**/*.js"],
+      "formatter": {
+        "enabled": false
+      }
+    }
+  ]
 }

--- a/biome.json
+++ b/biome.json
@@ -1,6 +1,7 @@
 {
   "formatter": {
     "enabled": true,
+    "includes": ["**/*.js", "!lib/defs.js", "!test"],
     "formatWithErrors": false,
     "indentStyle": "space",
     "indentWidth": 2,
@@ -10,6 +11,7 @@
   },
   "linter": {
     "enabled": true,
+    "includes": ["**/*.js", "!lib/defs.js"],
     "rules": {
       "complexity": {
         "noCommaOperator": "error",
@@ -43,16 +45,5 @@
       "semicolons": "always",
       "trailingCommas": "all"
     }
-  },
-  "files": {
-    "includes": ["**/*.js", "!lib/defs.js"]
-  },
-  "overrides": [
-    {
-      "includes": ["test/**/*.js"],
-      "formatter": {
-        "enabled": false
-      }
-    }
-  ]
+  }
 }

--- a/biome.json
+++ b/biome.json
@@ -37,7 +37,6 @@
   "javascript": {
     "formatter": {
       "arrowParentheses": "always",
-      "bracketSameLine": true,
       "bracketSpacing": false,
       "jsxQuoteStyle": "double",
       "quoteProperties": "asNeeded",

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,6 +2,11 @@ pre-commit:
   commands:
     format:
       glob: "**/*.js"
-      exclude: "test/**/*.js"
+      exclude:
+        - "test/*.js"
       run: npx biome format {staged_files} --write
+      stage_fixed: true
+    lint:
+      glob: "**/*.js"
+      run: npx biome lint {staged_files} --write
       stage_fixed: true

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,5 +2,6 @@ pre-commit:
   commands:
     format:
       glob: "**/*.js"
+      exclude: "test/**/*.js"
       run: npx biome format {staged_files} --write
       stage_fixed: true

--- a/test/bitset.js
+++ b/test/bitset.js
@@ -5,93 +5,47 @@ const {forAll, data: arb, label, choice, transform} = claire;
 
 const PosInt = transform(Math.floor, arb.Positive);
 
-const EmptyBitSet = label(
-  'bitset',
-  transform(
-    (size) => {
-      return new BitSet(size);
-    },
-    choice(arb.Nothing, PosInt),
-  ),
-);
+const EmptyBitSet = label('bitset', transform((size) => {
+  return new BitSet(size);
+}, choice(arb.Nothing, PosInt)));
 
 suite('BitSet', () => {
-  test(
-    'get bit',
-    forAll(EmptyBitSet, PosInt)
-      .satisfy((b, bit) => {
-        b.set(bit);
-        return b.get(bit);
-      })
-      .asTest(),
-  );
+  test('get bit', forAll(EmptyBitSet, PosInt).satisfy((b, bit) => {
+    b.set(bit);
+    return b.get(bit);
+  }).asTest());
 
-  test(
-    'clear bit',
-    forAll(EmptyBitSet, PosInt)
-      .satisfy((b, bit) => {
-        b.set(bit);
-        b.clear(bit);
-        return !b.get(bit);
-      })
-      .asTest(),
-  );
+  test('clear bit', forAll(EmptyBitSet, PosInt).satisfy((b, bit) => {
+    b.set(bit);
+    b.clear(bit);
+    return !b.get(bit);
+  }).asTest());
 
-  test(
-    'next set of empty',
-    forAll(EmptyBitSet)
-      .satisfy((b) => {
-        return b.nextSetBit(0) === -1;
-      })
-      .asTest(),
-  );
+  test('next set of empty', forAll(EmptyBitSet).satisfy((b) => {
+    return b.nextSetBit(0) === -1;
+  }).asTest());
 
-  test(
-    'next set of one bit',
-    forAll(EmptyBitSet, PosInt)
-      .satisfy((b, bit) => {
-        b.set(bit);
-        return b.nextSetBit(0) === bit;
-      })
-      .asTest(),
-  );
+  test('next set of one bit', forAll(EmptyBitSet, PosInt).satisfy((b, bit) => {
+    b.set(bit);
+    return b.nextSetBit(0) === bit;
+  }).asTest());
 
-  test(
-    'next set same bit',
-    forAll(EmptyBitSet, PosInt)
-      .satisfy((b, bit) => {
-        b.set(bit);
-        return b.nextSetBit(bit) === bit;
-      })
-      .asTest(),
-  );
+  test('next set same bit', forAll(EmptyBitSet, PosInt).satisfy((b, bit) => {
+    b.set(bit);
+    return b.nextSetBit(bit) === bit;
+  }).asTest());
 
-  test(
-    'next set following bit',
-    forAll(EmptyBitSet, PosInt)
-      .satisfy((b, bit) => {
-        b.set(bit);
-        return b.nextSetBit(bit + 1) === -1;
-      })
-      .asTest(),
-  );
+  test('next set following bit', forAll(EmptyBitSet, PosInt).satisfy((b, bit) => {
+    b.set(bit);
+    return b.nextSetBit(bit + 1) === -1;
+  }).asTest());
 
-  test(
-    'next clear of empty',
-    forAll(EmptyBitSet, PosInt)
-      .satisfy((b, bit) => {
-        return b.nextClearBit(bit) === bit;
-      })
-      .asTest(),
-  );
+  test('next clear of empty', forAll(EmptyBitSet, PosInt).satisfy((b, bit) => {
+    return b.nextClearBit(bit) === bit;
+  }).asTest());
 
-  test(
-    'next clear of one set',
-    forAll(EmptyBitSet, PosInt)
-      .satisfy((b, bit) => {
-        b.set(bit);
-        return b.nextClearBit(bit) === bit + 1;
-      })
-      .asTest(),
-  );
+  test('next clear of one set', forAll(EmptyBitSet, PosInt).satisfy((b, bit) => {
+    b.set(bit);
+    return b.nextClearBit(bit) === bit + 1;
+  }).asTest());
 });

--- a/test/callback_api.js
+++ b/test/callback_api.js
@@ -71,11 +71,9 @@ suite('connect', () => {
 
 suite('updateSecret', () => {
   test('updateSecret', (done) => {
-    connect(
-      kCallback((c) => {
-        c.updateSecret(Buffer.from('new secret'), 'no reason', doneCallback(done));
-      }),
-    );
+    connect(kCallback((c) => {
+      c.updateSecret(Buffer.from('new secret'), 'no reason', doneCallback(done));
+    }));
   });
 });
 
@@ -86,16 +84,11 @@ const channel_test_fn = (method) => {
       options = {};
     }
     test(name, (done) => {
-      connect(
-        kCallback((c) => {
-          c[method](
-            options,
-            kCallback((ch) => {
-              chfun(ch, done);
-            }, done),
-          );
-        }, done),
-      );
+      connect(kCallback((c) => {
+        c[method](options, kCallback((ch) => {
+          chfun(ch, done);
+        }, done));
+      }, done));
     });
   };
 };
@@ -114,34 +107,19 @@ suite('channel open', () => {
 
 suite('assert, check, delete', () => {
   channel_test('assert, check, delete queue', (ch, done) => {
-    ch.assertQueue(
-      'test.cb.queue',
-      {},
-      kCallback((_q) => {
-        ch.checkQueue(
-          'test.cb.queue',
-          kCallback((_ok) => {
-            ch.deleteQueue('test.cb.queue', {}, doneCallback(done));
-          }, done),
-        );
-      }, done),
-    );
+    ch.assertQueue('test.cb.queue', {}, kCallback((_q) => {
+      ch.checkQueue('test.cb.queue', kCallback((_ok) => {
+        ch.deleteQueue('test.cb.queue', {}, doneCallback(done));
+      }, done));
+    }, done));
   });
 
   channel_test('assert, check, delete exchange', (ch, done) => {
-    ch.assertExchange(
-      'test.cb.exchange',
-      'topic',
-      {},
-      kCallback((_ex) => {
-        ch.checkExchange(
-          'test.cb.exchange',
-          kCallback((_ok) => {
-            ch.deleteExchange('test.cb.exchange', {}, doneCallback(done));
-          }, done),
-        );
-      }, done),
-    );
+    ch.assertExchange('test.cb.exchange', 'topic', {}, kCallback((_ex) => {
+      ch.checkExchange('test.cb.exchange', kCallback((_ok) => {
+        ch.deleteExchange('test.cb.exchange', {}, doneCallback(done));
+      }, done));
+    }, done));
   });
 
   channel_test('fail on check non-queue', (ch, done) => {
@@ -159,38 +137,19 @@ suite('assert, check, delete', () => {
 
 suite('bindings', () => {
   channel_test('bind queue', (ch, done) => {
-    ch.assertQueue(
-      'test.cb.bindq',
-      {},
-      kCallback((q) => {
-        ch.assertExchange(
-          'test.cb.bindex',
-          'fanout',
-          {},
-          kCallback((ex) => {
-            ch.bindQueue(q.queue, ex.exchange, '', {}, doneCallback(done));
-          }, done),
-        );
-      }, done),
-    );
+    ch.assertQueue('test.cb.bindq', {}, kCallback((q) => {
+      ch.assertExchange('test.cb.bindex', 'fanout', {}, kCallback((ex) => {
+        ch.bindQueue(q.queue, ex.exchange, '', {}, doneCallback(done));
+      }, done));
+    }, done));
   });
 
   channel_test('bind exchange', (ch, done) => {
-    ch.assertExchange(
-      'test.cb.bindex1',
-      'fanout',
-      {},
-      kCallback((ex1) => {
-        ch.assertExchange(
-          'test.cb.bindex2',
-          'fanout',
-          {},
-          kCallback((ex2) => {
-            ch.bindExchange(ex1.exchange, ex2.exchange, '', {}, doneCallback(done));
-          }, done),
-        );
-      }, done),
-    );
+    ch.assertExchange('test.cb.bindex1', 'fanout', {}, kCallback((ex1) => {
+      ch.assertExchange('test.cb.bindex2', 'fanout', {}, kCallback((ex2) => {
+        ch.bindExchange(ex1.exchange, ex2.exchange, '', {}, doneCallback(done));
+      }, done));
+    }, done));
   });
 });
 

--- a/test/channel.js
+++ b/test/channel.js
@@ -78,687 +78,491 @@ function open(ch) {
 }
 
 suite('channel open and close', () => {
-  test(
-    'open',
-    channelTest(
-      (ch, done) => {
-        open(ch).then(succeed(done), fail(done));
-      },
-      (_send, _wait, done) => {
-        done();
-      },
-    ),
-  );
+  test('open', channelTest((ch, done) => {
+    open(ch).then(succeed(done), fail(done));
+  }, (_send, _wait, done) => {
+    done();
+  }));
 
-  test(
-    'bad server',
-    baseChannelTest(
-      (c, done) => {
-        const ch = new Channel(c);
-        open(ch).then(fail(done), succeed(done));
-      },
-      (send, wait, done) =>
-        wait(defs.ChannelOpen)()
-          .then((open) => {
-            send(defs.ChannelCloseOk, {}, open.channel);
-          })
-          .then(succeed(done), fail(done)),
-    ),
-  );
+  test('bad server', baseChannelTest((c, done) => {
+    const ch = new Channel(c);
+    open(ch).then(fail(done), succeed(done));
+  }, (send, wait, done) => wait(defs.ChannelOpen)()
+    .then((open) => {
+      send(defs.ChannelCloseOk, {}, open.channel);
+    })
+    .then(succeed(done), fail(done))));
 
-  test(
-    'open, close',
-    channelTest(
-      (ch, done) => {
-        open(ch)
-          .then(
-            () =>
-              new Promise((resolve) => {
-                ch.closeBecause('Bye', defs.constants.REPLY_SUCCESS, resolve);
-              }),
-          )
-          .then(succeed(done), fail(done));
-      },
-      (send, wait, done, ch) =>
-        wait(defs.ChannelClose)()
-          .then((_close) => {
-            send(defs.ChannelCloseOk, {}, ch);
-          })
-          .then(succeed(done), fail(done)),
-    ),
-  );
+  test('open, close', channelTest((ch, done) => {
+    open(ch)
+      .then(() => new Promise((resolve) => {
+        ch.closeBecause('Bye', defs.constants.REPLY_SUCCESS, resolve);
+      }))
+      .then(succeed(done), fail(done));
+  }, (send, wait, done, ch) => wait(defs.ChannelClose)()
+    .then((_close) => {
+      send(defs.ChannelCloseOk, {}, ch);
+    })
+    .then(succeed(done), fail(done))));
 
-  test(
-    'server close',
-    channelTest(
-      (ch, done) => {
-        ch.on('error', (error) => {
-          assert.strictEqual(504, error.code);
-          assert.strictEqual(0, error.classId);
-          assert.strictEqual(0, error.methodId);
-          succeed(done)();
+  test('server close', channelTest((ch, done) => {
+    ch.on('error', (error) => {
+      assert.strictEqual(504, error.code);
+      assert.strictEqual(0, error.classId);
+      assert.strictEqual(0, error.methodId);
+      succeed(done)();
+    });
+    open(ch);
+  }, (send, wait, done, ch) => {
+    send(defs.ChannelClose, {
+      replyText: 'Forced close',
+      replyCode: defs.constants.CHANNEL_ERROR,
+      classId: 0,
+      methodId: 0,
+    }, ch);
+    wait(defs.ChannelCloseOk)().then(succeed(done), fail(done));
+  }));
+
+  test('overlapping channel/server close', channelTest((ch, done, conn) => {
+    const both = latch(2, done);
+    conn.on('error', succeed(both));
+    ch.on('close', succeed(both));
+    open(ch).then(() => {
+      ch.closeBecause('Bye', defs.constants.REPLY_SUCCESS);
+    }, fail(both));
+  }, (send, wait, done, _ch) => {
+    wait(defs.ChannelClose)()
+      .then(() => {
+        send(defs.ConnectionClose, {
+          replyText: 'Got there first',
+          replyCode: defs.constants.INTERNAL_ERROR,
+          classId: 0,
+          methodId: 0,
+        }, 0);
+      })
+      .then(wait(defs.ConnectionCloseOk))
+      .then(succeed(done), fail(done));
+  }));
+
+  test('double close', channelTest((ch, done) => {
+    open(ch)
+      .then(() => {
+        ch.closeBecause('First close', defs.constants.REPLY_SUCCESS);
+        // NB no synchronisation, we do this straight away
+        assert.throws(() => {
+          ch.closeBecause('Second close', defs.constants.REPLY_SUCCESS);
         });
-        open(ch);
-      },
-      (send, wait, done, ch) => {
-        send(
-          defs.ChannelClose,
-          {
-            replyText: 'Forced close',
-            replyCode: defs.constants.CHANNEL_ERROR,
-            classId: 0,
-            methodId: 0,
-          },
-          ch,
-        );
-        wait(defs.ChannelCloseOk)().then(succeed(done), fail(done));
-      },
-    ),
-  );
-
-  test(
-    'overlapping channel/server close',
-    channelTest(
-      (ch, done, conn) => {
-        const both = latch(2, done);
-        conn.on('error', succeed(both));
-        ch.on('close', succeed(both));
-        open(ch).then(() => {
-          ch.closeBecause('Bye', defs.constants.REPLY_SUCCESS);
-        }, fail(both));
-      },
-      (send, wait, done, _ch) => {
-        wait(defs.ChannelClose)()
-          .then(() => {
-            send(
-              defs.ConnectionClose,
-              {
-                replyText: 'Got there first',
-                replyCode: defs.constants.INTERNAL_ERROR,
-                classId: 0,
-                methodId: 0,
-              },
-              0,
-            );
-          })
-          .then(wait(defs.ConnectionCloseOk))
-          .then(succeed(done), fail(done));
-      },
-    ),
-  );
-
-  test(
-    'double close',
-    channelTest(
-      (ch, done) => {
-        open(ch)
-          .then(() => {
-            ch.closeBecause('First close', defs.constants.REPLY_SUCCESS);
-            // NB no synchronisation, we do this straight away
-            assert.throws(() => {
-              ch.closeBecause('Second close', defs.constants.REPLY_SUCCESS);
-            });
-          })
-          .then(succeed(done), fail(done));
-      },
-      (send, wait, done, ch) => {
-        wait(defs.ChannelClose)()
-          .then(() => {
-            send(defs.ChannelCloseOk, {}, ch);
-          })
-          .then(succeed(done), fail(done));
-      },
-    ),
-  );
+      })
+      .then(succeed(done), fail(done));
+  }, (send, wait, done, ch) => {
+    wait(defs.ChannelClose)()
+      .then(() => {
+        send(defs.ChannelCloseOk, {}, ch);
+      })
+      .then(succeed(done), fail(done));
+  }));
 }); //suite
 
 suite('channel machinery', () => {
-  test(
-    'RPC',
-    channelTest(
-      (ch, done) => {
-        const rpcLatch = latch(3, done);
-        open(ch)
-          .then(() => {
-            function wheeboom(err, _f) {
-              if (err !== null) rpcLatch(err);
-              else rpcLatch();
-            }
-
-            const fields = {
-              prefetchCount: 10,
-              prefetchSize: 0,
-              global: false,
-            };
-
-            ch._rpc(defs.BasicQos, fields, defs.BasicQosOk, wheeboom);
-            ch._rpc(defs.BasicQos, fields, defs.BasicQosOk, wheeboom);
-            ch._rpc(defs.BasicQos, fields, defs.BasicQosOk, wheeboom);
-          })
-          .then(null, fail(rpcLatch));
-      },
-      (send, wait, done, ch) => {
-        function sendOk(_f) {
-          send(defs.BasicQosOk, {}, ch);
+  test('RPC', channelTest((ch, done) => {
+    const rpcLatch = latch(3, done);
+    open(ch)
+      .then(() => {
+        function wheeboom(err, _f) {
+          if (err !== null) rpcLatch(err);
+          else rpcLatch();
         }
 
-        return wait(defs.BasicQos)()
-          .then(sendOk)
-          .then(wait(defs.BasicQos))
-          .then(sendOk)
-          .then(wait(defs.BasicQos))
-          .then(sendOk)
-          .then(succeed(done), fail(done));
-      },
-    ),
-  );
+        const fields = {
+          prefetchCount: 10,
+          prefetchSize: 0,
+          global: false,
+        };
 
-  test(
-    'Bad RPC',
-    channelTest(
-      (ch, done) => {
-        // We want to see the RPC rejected and the channel closed (with an
-        // error)
-        const errLatch = latch(2, done);
-        ch.on('error', (error) => {
-          assert.strictEqual(505, error.code);
-          assert.strictEqual(60, error.classId);
-          assert.strictEqual(72, error.methodId);
-          succeed(errLatch)();
-        });
+        ch._rpc(defs.BasicQos, fields, defs.BasicQosOk, wheeboom);
+        ch._rpc(defs.BasicQos, fields, defs.BasicQosOk, wheeboom);
+        ch._rpc(defs.BasicQos, fields, defs.BasicQosOk, wheeboom);
+      })
+      .then(null, fail(rpcLatch));
+  }, (send, wait, done, ch) => {
+    function sendOk(_f) {
+      send(defs.BasicQosOk, {}, ch);
+    }
 
-        open(ch).then(() => {
-          ch._rpc(defs.BasicRecover, {requeue: true}, defs.BasicRecoverOk, (err) => {
-            if (err !== null) errLatch();
-            else errLatch(new Error('Expected RPC failure'));
-          });
-        }, fail(errLatch));
-      },
-      (send, wait, done, ch) =>
-        wait()()
-          .then(() => {
-            send(defs.BasicGetEmpty, {clusterId: ''}, ch);
-          }) // oh wait! that was wrong! expect a channel close
-          .then(wait(defs.ChannelClose))
-          .then(() => {
-            send(defs.ChannelCloseOk, {}, ch);
-          })
-          .then(succeed(done), fail(done)),
-    ),
-  );
+    return wait(defs.BasicQos)()
+      .then(sendOk)
+      .then(wait(defs.BasicQos))
+      .then(sendOk)
+      .then(wait(defs.BasicQos))
+      .then(sendOk)
+      .then(succeed(done), fail(done));
+  }));
 
-  test(
-    'RPC on closed channel',
-    channelTest(
-      (ch, done) => {
-        open(ch);
+  test('Bad RPC', channelTest((ch, done) => {
+    // We want to see the RPC rejected and the channel closed (with an
+    // error)
+    const errLatch = latch(2, done);
+    ch.on('error', (error) => {
+      assert.strictEqual(505, error.code);
+      assert.strictEqual(60, error.classId);
+      assert.strictEqual(72, error.methodId);
+      succeed(errLatch)();
+    });
 
-        const close = new Promise((resolve) => {
-          ch.on('error', (error) => {
-            assert.strictEqual(504, error.code);
-            assert.strictEqual(0, error.classId);
-            assert.strictEqual(0, error.methodId);
-            resolve();
-          });
-        });
+    open(ch).then(() => {
+      ch._rpc(defs.BasicRecover, {requeue: true}, defs.BasicRecoverOk, (err) => {
+        if (err !== null) errLatch();
+        else errLatch(new Error('Expected RPC failure'));
+      });
+    }, fail(errLatch));
+  }, (send, wait, done, ch) => wait()()
+    .then(() => {
+      send(defs.BasicGetEmpty, {clusterId: ''}, ch);
+    }) // oh wait! that was wrong! expect a channel close
+    .then(wait(defs.ChannelClose))
+    .then(() => {
+      send(defs.ChannelCloseOk, {}, ch);
+    })
+    .then(succeed(done), fail(done))));
 
-        function failureCb(resolve, reject) {
-          return (err) => {
-            if (err !== null) resolve();
-            else reject();
-          };
-        }
+  test('RPC on closed channel', channelTest((ch, done) => {
+    open(ch);
 
-        const fail1 = new Promise((resolve, reject) =>
-          ch._rpc(defs.BasicRecover, {requeue: true}, defs.BasicRecoverOk, failureCb(resolve, reject)),
-        );
+    const close = new Promise((resolve) => {
+      ch.on('error', (error) => {
+        assert.strictEqual(504, error.code);
+        assert.strictEqual(0, error.classId);
+        assert.strictEqual(0, error.methodId);
+        resolve();
+      });
+    });
 
-        const fail2 = new Promise((resolve, reject) =>
-          ch._rpc(defs.BasicRecover, {requeue: true}, defs.BasicRecoverOk, failureCb(resolve, reject)),
-        );
+    function failureCb(resolve, reject) {
+      return (err) => {
+        if (err !== null) resolve();
+        else reject();
+      };
+    }
 
-        Promise.all([close, fail1, fail2]).then(succeed(done)).catch(fail(done));
-      },
-      (send, wait, done, ch) => {
-        wait(defs.BasicRecover)()
-          .then(() => {
-            send(
-              defs.ChannelClose,
-              {
-                replyText: 'Nuh-uh!',
-                replyCode: defs.constants.CHANNEL_ERROR,
-                methodId: 0,
-                classId: 0,
-              },
-              ch,
-            );
-            return wait(defs.ChannelCloseOk);
-          })
-          .then(succeed(done))
-          .catch(fail(done));
-      },
-    ),
-  );
+    const fail1 = new Promise((resolve, reject) =>
+      ch._rpc(defs.BasicRecover, {requeue: true}, defs.BasicRecoverOk, failureCb(resolve, reject)),
+    );
 
-  test(
-    'publish all < single chunk threshold',
-    channelTest(
-      (ch, done) => {
-        open(ch)
-          .then(() => {
-            ch.sendMessage(
-              {
-                exchange: 'foo',
-                routingKey: 'bar',
-                mandatory: false,
-                immediate: false,
-                ticket: 0,
-              },
-              {},
-              Buffer.from('foobar'),
-            );
-          })
-          .then(succeed(done), fail(done));
-      },
-      (_send, wait, done, _ch) => {
-        wait(defs.BasicPublish)()
-          .then(wait(defs.BasicProperties))
-          .then(wait(undefined)) // content frame
-          .then((f) => {
-            assert.equal('foobar', f.content.toString());
-          })
-          .then(succeed(done), fail(done));
-      },
-    ),
-  );
+    const fail2 = new Promise((resolve, reject) =>
+      ch._rpc(defs.BasicRecover, {requeue: true}, defs.BasicRecoverOk, failureCb(resolve, reject)),
+    );
 
-  test(
-    'publish content > single chunk threshold',
-    channelTest(
-      (ch, done) => {
-        open(ch);
-        completes(() => {
-          ch.sendMessage(
-            {
-              exchange: 'foo',
-              routingKey: 'bar',
-              mandatory: false,
-              immediate: false,
-              ticket: 0,
-            },
-            {},
-            Buffer.alloc(3000),
-          );
-        }, done);
-      },
-      (_send, wait, done, _ch) => {
-        wait(defs.BasicPublish)()
-          .then(wait(defs.BasicProperties))
-          .then(wait(undefined)) // content frame
-          .then((f) => {
-            assert.equal(3000, f.content.length);
-          })
-          .then(succeed(done), fail(done));
-      },
-    ),
-  );
+    Promise.all([close, fail1, fail2]).then(succeed(done)).catch(fail(done));
+  }, (send, wait, done, ch) => {
+    wait(defs.BasicRecover)()
+      .then(() => {
+        send(defs.ChannelClose, {
+          replyText: 'Nuh-uh!',
+          replyCode: defs.constants.CHANNEL_ERROR,
+          methodId: 0,
+          classId: 0,
+        }, ch);
+        return wait(defs.ChannelCloseOk);
+      })
+      .then(succeed(done))
+      .catch(fail(done));
+  }));
 
-  test(
-    'publish method & headers > threshold',
-    channelTest(
-      (ch, done) => {
-        open(ch);
-        completes(() => {
-          ch.sendMessage(
-            {
-              exchange: 'foo',
-              routingKey: 'bar',
-              mandatory: false,
-              immediate: false,
-              ticket: 0,
-            },
-            {
-              headers: {foo: Buffer.alloc(3000)},
-            },
-            Buffer.from('foobar'),
-          );
-        }, done);
-      },
-      (_send, wait, done, _ch) => {
-        wait(defs.BasicPublish)()
-          .then(wait(defs.BasicProperties))
-          .then(wait(undefined)) // content frame
-          .then((f) => {
-            assert.equal('foobar', f.content.toString());
-          })
-          .then(succeed(done), fail(done));
-      },
-    ),
-  );
+  test('publish all < single chunk threshold', channelTest((ch, done) => {
+    open(ch)
+      .then(() => {
+        ch.sendMessage({
+          exchange: 'foo',
+          routingKey: 'bar',
+          mandatory: false,
+          immediate: false,
+          ticket: 0,
+        }, {}, Buffer.from('foobar'));
+      })
+      .then(succeed(done), fail(done));
+  }, (_send, wait, done, _ch) => {
+    wait(defs.BasicPublish)()
+      .then(wait(defs.BasicProperties))
+      .then(wait(undefined)) // content frame
+      .then((f) => {
+        assert.equal('foobar', f.content.toString());
+      })
+      .then(succeed(done), fail(done));
+  }));
 
-  test(
-    'publish zero-length message',
-    channelTest(
-      (ch, done) => {
-        open(ch);
-        completes(() => {
-          ch.sendMessage(
-            {
-              exchange: 'foo',
-              routingKey: 'bar',
-              mandatory: false,
-              immediate: false,
-              ticket: 0,
-            },
-            {},
-            Buffer.alloc(0),
-          );
-          ch.sendMessage(
-            {
-              exchange: 'foo',
-              routingKey: 'bar',
-              mandatory: false,
-              immediate: false,
-              ticket: 0,
-            },
-            {},
-            Buffer.alloc(0),
-          );
-        }, done);
-      },
-      (_send, wait, done, _ch) => {
-        wait(defs.BasicPublish)()
-          .then(wait(defs.BasicProperties))
-          // no content frame for a zero-length message
-          .then(wait(defs.BasicPublish))
-          .then(succeed(done), fail(done));
-      },
-    ),
-  );
+  test('publish content > single chunk threshold', channelTest((ch, done) => {
+    open(ch);
+    completes(() => {
+      ch.sendMessage({
+        exchange: 'foo',
+        routingKey: 'bar',
+        mandatory: false,
+        immediate: false,
+        ticket: 0,
+      }, {}, Buffer.alloc(3000));
+    }, done);
+  }, (_send, wait, done, _ch) => {
+    wait(defs.BasicPublish)()
+      .then(wait(defs.BasicProperties))
+      .then(wait(undefined)) // content frame
+      .then((f) => {
+        assert.equal(3000, f.content.length);
+      })
+      .then(succeed(done), fail(done));
+  }));
 
-  test(
-    'delivery',
-    channelTest(
-      (ch, done) => {
-        open(ch);
-        ch.on('delivery', (m) => {
-          completes(() => {
-            assert.equal('barfoo', m.content.toString());
-          }, done);
-        });
-      },
-      (send, _wait, done, ch) => {
-        completes(() => {
-          send(defs.BasicDeliver, DELIVER_FIELDS, ch, Buffer.from('barfoo'));
-        }, done);
-      },
-    ),
-  );
+  test('publish method & headers > threshold', channelTest((ch, done) => {
+    open(ch);
+    completes(() => {
+      ch.sendMessage({
+        exchange: 'foo',
+        routingKey: 'bar',
+        mandatory: false,
+        immediate: false,
+        ticket: 0,
+      }, {
+        headers: {foo: Buffer.alloc(3000)},
+      }, Buffer.from('foobar'));
+    }, done);
+  }, (_send, wait, done, _ch) => {
+    wait(defs.BasicPublish)()
+      .then(wait(defs.BasicProperties))
+      .then(wait(undefined)) // content frame
+      .then((f) => {
+        assert.equal('foobar', f.content.toString());
+      })
+      .then(succeed(done), fail(done));
+  }));
 
-  test(
-    'zero byte msg',
-    channelTest(
-      (ch, done) => {
-        open(ch);
-        ch.on('delivery', (m) => {
-          completes(() => {
-            assert.deepEqual(Buffer.alloc(0), m.content);
-          }, done);
-        });
-      },
-      (send, _wait, done, ch) => {
-        completes(() => {
-          send(defs.BasicDeliver, DELIVER_FIELDS, ch, Buffer.from(''));
-        }, done);
-      },
-    ),
-  );
+  test('publish zero-length message', channelTest((ch, done) => {
+    open(ch);
+    completes(() => {
+      ch.sendMessage({
+        exchange: 'foo',
+        routingKey: 'bar',
+        mandatory: false,
+        immediate: false,
+        ticket: 0,
+      }, {}, Buffer.alloc(0));
+      ch.sendMessage({
+        exchange: 'foo',
+        routingKey: 'bar',
+        mandatory: false,
+        immediate: false,
+        ticket: 0,
+      }, {}, Buffer.alloc(0));
+    }, done);
+  }, (_send, wait, done, _ch) => {
+    wait(defs.BasicPublish)()
+      .then(wait(defs.BasicProperties))
+      // no content frame for a zero-length message
+      .then(wait(defs.BasicPublish))
+      .then(succeed(done), fail(done));
+  }));
 
-  test(
-    'bad delivery',
-    channelTest(
-      (ch, done) => {
-        const errorAndClose = latch(2, done);
-        ch.on('error', (error) => {
-          assert.strictEqual(505, error.code);
-          assert.strictEqual(60, error.classId);
-          assert.strictEqual(60, error.methodId);
-          succeed(errorAndClose)();
-        });
-        ch.on('close', succeed(errorAndClose));
-        open(ch);
-      },
-      (send, wait, done, ch) => {
-        send(defs.BasicDeliver, DELIVER_FIELDS, ch);
-        // now send another deliver without having sent the content
-        send(defs.BasicDeliver, DELIVER_FIELDS, ch);
-        return wait(defs.ChannelClose)()
-          .then(() => {
-            send(defs.ChannelCloseOk, {}, ch);
-          })
-          .then(succeed(done), fail(done));
-      },
-    ),
-  );
+  test('delivery', channelTest((ch, done) => {
+    open(ch);
+    ch.on('delivery', (m) => {
+      completes(() => {
+        assert.equal('barfoo', m.content.toString());
+      }, done);
+    });
+  }, (send, _wait, done, ch) => {
+    completes(() => {
+      send(defs.BasicDeliver, DELIVER_FIELDS, ch, Buffer.from('barfoo'));
+    }, done);
+  }));
 
-  test(
-    'bad content send',
-    channelTest(
-      (ch, done) => {
-        completes(() => {
-          open(ch);
-          assert.throws(() => {
-            ch.sendMessage({routingKey: 'foo', exchange: 'amq.direct'}, {}, null);
-          });
-        }, done);
-      },
-      (_send, _wait, done, _ch) => {
-        done();
-      },
-    ),
-  );
+  test('zero byte msg', channelTest((ch, done) => {
+    open(ch);
+    ch.on('delivery', (m) => {
+      completes(() => {
+        assert.deepEqual(Buffer.alloc(0), m.content);
+      }, done);
+    });
+  }, (send, _wait, done, ch) => {
+    completes(() => {
+      send(defs.BasicDeliver, DELIVER_FIELDS, ch, Buffer.from(''));
+    }, done);
+  }));
 
-  test(
-    'bad properties send',
-    channelTest(
-      (ch, done) => {
-        completes(() => {
-          open(ch);
-          assert.throws(() => {
-            ch.sendMessage({routingKey: 'foo', exchange: 'amq.direct'}, {contentEncoding: 7}, Buffer.from('foobar'));
-          });
-        }, done);
-      },
-      (_send, _wait, done, _ch) => {
-        done();
-      },
-    ),
-  );
+  test('bad delivery', channelTest((ch, done) => {
+    const errorAndClose = latch(2, done);
+    ch.on('error', (error) => {
+      assert.strictEqual(505, error.code);
+      assert.strictEqual(60, error.classId);
+      assert.strictEqual(60, error.methodId);
+      succeed(errorAndClose)();
+    });
+    ch.on('close', succeed(errorAndClose));
+    open(ch);
+  }, (send, wait, done, ch) => {
+    send(defs.BasicDeliver, DELIVER_FIELDS, ch);
+    // now send another deliver without having sent the content
+    send(defs.BasicDeliver, DELIVER_FIELDS, ch);
+    return wait(defs.ChannelClose)()
+      .then(() => {
+        send(defs.ChannelCloseOk, {}, ch);
+      })
+      .then(succeed(done), fail(done));
+  }));
 
-  test(
-    'bad consumer',
-    channelTest(
-      (ch, done) => {
-        const errorAndClose = latch(2, done);
-        ch.on('delivery', () => {
-          throw new Error('I am a bad consumer');
-        });
-        ch.on('error', (error) => {
-          assert.strictEqual(541, error.code);
-          assert.strictEqual(undefined, error.classId);
-          assert.strictEqual(undefined, error.methodId);
-          succeed(errorAndClose)();
-        });
-        ch.on('close', succeed(errorAndClose));
-        open(ch);
-      },
-      (send, wait, done, ch) => {
-        send(defs.BasicDeliver, DELIVER_FIELDS, ch, Buffer.from('barfoo'));
-        return wait(defs.ChannelClose)()
-          .then(() => {
-            send(defs.ChannelCloseOk, {}, ch);
-          })
-          .then(succeed(done), fail(done));
-      },
-    ),
-  );
+  test('bad content send', channelTest((ch, done) => {
+    completes(() => {
+      open(ch);
+      assert.throws(() => {
+        ch.sendMessage({routingKey: 'foo', exchange: 'amq.direct'}, {}, null);
+      });
+    }, done);
+  }, (_send, _wait, done, _ch) => {
+    done();
+  }));
 
-  test(
-    'bad send in consumer',
-    channelTest(
-      (ch, done) => {
-        const errorAndClose = latch(2, done);
-        ch.on('close', succeed(errorAndClose));
-        ch.on('error', (error) => {
-          assert.strictEqual(541, error.code);
-          assert.strictEqual(undefined, error.classId);
-          assert.strictEqual(undefined, error.methodId);
-          succeed(errorAndClose)();
-        });
+  test('bad properties send', channelTest((ch, done) => {
+    completes(() => {
+      open(ch);
+      assert.throws(() => {
+        ch.sendMessage({routingKey: 'foo', exchange: 'amq.direct'}, {contentEncoding: 7}, Buffer.from('foobar'));
+      });
+    }, done);
+  }, (_send, _wait, done, _ch) => {
+    done();
+  }));
 
-        ch.on('delivery', () => {
-          ch.sendMessage({routingKey: 'foo', exchange: 'amq.direct'}, {}, null); // can't send null
-        });
+  test('bad consumer', channelTest((ch, done) => {
+    const errorAndClose = latch(2, done);
+    ch.on('delivery', () => {
+      throw new Error('I am a bad consumer');
+    });
+    ch.on('error', (error) => {
+      assert.strictEqual(541, error.code);
+      assert.strictEqual(undefined, error.classId);
+      assert.strictEqual(undefined, error.methodId);
+      succeed(errorAndClose)();
+    });
+    ch.on('close', succeed(errorAndClose));
+    open(ch);
+  }, (send, wait, done, ch) => {
+    send(defs.BasicDeliver, DELIVER_FIELDS, ch, Buffer.from('barfoo'));
+    return wait(defs.ChannelClose)()
+      .then(() => {
+        send(defs.ChannelCloseOk, {}, ch);
+      })
+      .then(succeed(done), fail(done));
+  }));
 
-        open(ch);
-      },
-      (send, wait, done, ch) => {
-        completes(() => {
-          send(defs.BasicDeliver, DELIVER_FIELDS, ch, Buffer.from('barfoo'));
-        }, done);
-        return wait(defs.ChannelClose)()
-          .then(() => {
-            send(defs.ChannelCloseOk, {}, ch);
-          })
-          .then(succeed(done), fail(done));
-      },
-    ),
-  );
+  test('bad send in consumer', channelTest((ch, done) => {
+    const errorAndClose = latch(2, done);
+    ch.on('close', succeed(errorAndClose));
+    ch.on('error', (error) => {
+      assert.strictEqual(541, error.code);
+      assert.strictEqual(undefined, error.classId);
+      assert.strictEqual(undefined, error.methodId);
+      succeed(errorAndClose)();
+    });
 
-  test(
-    'return',
-    channelTest(
-      (ch, done) => {
-        ch.on('return', (m) => {
-          completes(() => {
-            assert.equal('barfoo', m.content.toString());
-          }, done);
-        });
-        open(ch);
-      },
-      (send, _wait, done, ch) => {
-        completes(() => {
-          send(defs.BasicReturn, DELIVER_FIELDS, ch, Buffer.from('barfoo'));
-        }, done);
-      },
-    ),
-  );
+    ch.on('delivery', () => {
+      ch.sendMessage({routingKey: 'foo', exchange: 'amq.direct'}, {}, null); // can't send null
+    });
 
-  test(
-    'cancel',
-    channelTest(
-      (ch, done) => {
-        ch.on('cancel', (f) => {
-          completes(() => {
-            assert.equal('product of society', f.consumerTag);
-          }, done);
-        });
-        open(ch);
-      },
-      (send, _wait, done, ch) => {
-        completes(() => {
-          send(
-            defs.BasicCancel,
-            {
-              consumerTag: 'product of society',
-              nowait: false,
-            },
-            ch,
-          );
-        }, done);
-      },
-    ),
-  );
+    open(ch);
+  }, (send, wait, done, ch) => {
+    completes(() => {
+      send(defs.BasicDeliver, DELIVER_FIELDS, ch, Buffer.from('barfoo'));
+    }, done);
+    return wait(defs.ChannelClose)()
+      .then(() => {
+        send(defs.ChannelCloseOk, {}, ch);
+      })
+      .then(succeed(done), fail(done));
+  }));
+
+  test('return', channelTest((ch, done) => {
+    ch.on('return', (m) => {
+      completes(() => {
+        assert.equal('barfoo', m.content.toString());
+      }, done);
+    });
+    open(ch);
+  }, (send, _wait, done, ch) => {
+    completes(() => {
+      send(defs.BasicReturn, DELIVER_FIELDS, ch, Buffer.from('barfoo'));
+    }, done);
+  }));
+
+  test('cancel', channelTest((ch, done) => {
+    ch.on('cancel', (f) => {
+      completes(() => {
+        assert.equal('product of society', f.consumerTag);
+      }, done);
+    });
+    open(ch);
+  }, (send, _wait, done, ch) => {
+    completes(() => {
+      send(defs.BasicCancel, {
+        consumerTag: 'product of society',
+        nowait: false,
+      }, ch);
+    }, done);
+  }));
 
   function confirmTest(variety, Method) {
-    return test(
-      `confirm ${variety}`,
-      channelTest(
-        (ch, done) => {
-          ch.on(variety, (f) => {
-            completes(() => {
-              assert.equal(1, f.deliveryTag);
-            }, done);
-          });
-          open(ch);
-        },
-        (send, _wait, done, ch) => {
-          completes(() => {
-            send(
-              Method,
-              {
-                deliveryTag: 1,
-                multiple: false,
-              },
-              ch,
-            );
-          }, done);
-        },
-      ),
-    );
+    return test(`confirm ${variety}`, channelTest((ch, done) => {
+      ch.on(variety, (f) => {
+        completes(() => {
+          assert.equal(1, f.deliveryTag);
+        }, done);
+      });
+      open(ch);
+    }, (send, _wait, done, ch) => {
+      completes(() => {
+        send(Method, {
+          deliveryTag: 1,
+          multiple: false,
+        }, ch);
+      }, done);
+    }));
   }
 
   confirmTest('ack', defs.BasicAck);
   confirmTest('nack', defs.BasicNack);
 
-  test(
-    'out-of-order acks',
-    channelTest(
-      (ch, done) => {
-        const allConfirms = latch(3, () => {
-          completes(() => {
-            assert.equal(0, ch.unconfirmed.length);
-            assert.equal(4, ch.lwm);
-          }, done);
-        });
-        ch.pushConfirmCallback(allConfirms);
-        ch.pushConfirmCallback(allConfirms);
-        ch.pushConfirmCallback(allConfirms);
-        open(ch);
-      },
-      (send, _wait, done, ch) => {
-        completes(() => {
-          send(defs.BasicAck, {deliveryTag: 2, multiple: false}, ch);
-          send(defs.BasicAck, {deliveryTag: 3, multiple: false}, ch);
-          send(defs.BasicAck, {deliveryTag: 1, multiple: false}, ch);
-        }, done);
-      },
-    ),
-  );
+  test('out-of-order acks', channelTest((ch, done) => {
+    const allConfirms = latch(3, () => {
+      completes(() => {
+        assert.equal(0, ch.unconfirmed.length);
+        assert.equal(4, ch.lwm);
+      }, done);
+    });
+    ch.pushConfirmCallback(allConfirms);
+    ch.pushConfirmCallback(allConfirms);
+    ch.pushConfirmCallback(allConfirms);
+    open(ch);
+  }, (send, _wait, done, ch) => {
+    completes(() => {
+      send(defs.BasicAck, {deliveryTag: 2, multiple: false}, ch);
+      send(defs.BasicAck, {deliveryTag: 3, multiple: false}, ch);
+      send(defs.BasicAck, {deliveryTag: 1, multiple: false}, ch);
+    }, done);
+  }));
 
-  test(
-    'not all out-of-order acks',
-    channelTest(
-      (ch, done) => {
-        const allConfirms = latch(2, () => {
-          completes(() => {
-            assert.equal(1, ch.unconfirmed.length);
-            assert.equal(3, ch.lwm);
-          }, done);
-        });
-        ch.pushConfirmCallback(allConfirms); // tag = 1
-        ch.pushConfirmCallback(allConfirms); // tag = 2
-        ch.pushConfirmCallback(() => {
-          done(new Error('Confirm callback should not be called'));
-        });
-        open(ch);
-      },
-      (send, _wait, done, ch) => {
-        completes(() => {
-          send(defs.BasicAck, {deliveryTag: 2, multiple: false}, ch);
-          send(defs.BasicAck, {deliveryTag: 1, multiple: false}, ch);
-        }, done);
-      },
-    ),
-  );
+  test('not all out-of-order acks', channelTest((ch, done) => {
+    const allConfirms = latch(2, () => {
+      completes(() => {
+        assert.equal(1, ch.unconfirmed.length);
+        assert.equal(3, ch.lwm);
+      }, done);
+    });
+    ch.pushConfirmCallback(allConfirms); // tag = 1
+    ch.pushConfirmCallback(allConfirms); // tag = 2
+    ch.pushConfirmCallback(() => {
+      done(new Error('Confirm callback should not be called'));
+    });
+    open(ch);
+  }, (send, _wait, done, ch) => {
+    completes(() => {
+      send(defs.BasicAck, {deliveryTag: 2, multiple: false}, ch);
+      send(defs.BasicAck, {deliveryTag: 1, multiple: false}, ch);
+    }, done);
+  }));
 });

--- a/test/channel_api.js
+++ b/test/channel_api.js
@@ -91,8 +91,7 @@ suite('assert, check, delete', () => {
 
   chtest('fail on reasserting queue with different options', (ch) => {
     const q = 'test.reassert-queue';
-    return ch
-      .assertQueue(q, {durable: false, autoDelete: true})
+    return ch.assertQueue(q, {durable: false, autoDelete: true})
       .then(() => expectFail(ch.assertQueue(q, {durable: false, autoDelete: false})));
   });
 
@@ -105,14 +104,10 @@ suite('assert, check, delete', () => {
     return ch.assertExchange(ex, 'fanout', EX_OPTS).then(() => expectFail(ch.assertExchange(ex, 'direct', EX_OPTS)));
   });
 
-  chtest(
-    'channel break on publishing to non-exchange',
-    (ch) =>
-      new Promise((resolve) => {
-        ch.on('error', resolve);
-        ch.publish(randomString(), '', Buffer.from('foobar'));
-      }),
-  );
+  chtest('channel break on publishing to non-exchange', (ch) => new Promise((resolve) => {
+    ch.on('error', resolve);
+    ch.publish(randomString(), '', Buffer.from('foobar'));
+  }));
 
   chtest('delete queue', (ch) => {
     const q = 'test.delete-queue';

--- a/test/connection.js
+++ b/test/connection.js
@@ -94,302 +94,209 @@ suite('Connection errors', () => {
 });
 
 suite('Connection open', () => {
-  test(
-    'happy',
-    connectionTest(
-      (c, done) => {
-        c.open(OPEN_OPTS, kCallback(succeed(done), fail(done)));
-      },
-      (send, wait, done) => {
-        happy_open(send, wait).then(succeed(done), fail(done));
-      },
-    ),
-  );
+  test('happy', connectionTest((c, done) => {
+    c.open(OPEN_OPTS, kCallback(succeed(done), fail(done)));
+  }, (send, wait, done) => {
+    happy_open(send, wait).then(succeed(done), fail(done));
+  }));
 
-  test(
-    'wrong first frame',
-    connectionTest(
-      (c, done) => {
-        c.open(OPEN_OPTS, kCallback(fail(done), succeed(done)));
-      },
-      (send, _wait, done) => {
-        // bad server! bad! whatever were you thinking?
-        completes(() => {
-          send(defs.ConnectionTune, {channelMax: 0, heartbeat: 0, frameMax: 0});
-        }, done);
-      },
-    ),
-  );
+  test('wrong first frame', connectionTest((c, done) => {
+    c.open(OPEN_OPTS, kCallback(fail(done), succeed(done)));
+  }, (send, _wait, done) => {
+    // bad server! bad! whatever were you thinking?
+    completes(() => {
+      send(defs.ConnectionTune, {channelMax: 0, heartbeat: 0, frameMax: 0});
+    }, done);
+  }));
 
-  test(
-    'unexpected socket close',
-    connectionTest(
-      (c, done) => {
-        c.open(OPEN_OPTS, kCallback(fail(done), succeed(done)));
-      },
-      (send, wait, done, socket) => {
-        send(defs.ConnectionStart, {
-          versionMajor: 0,
-          versionMinor: 9,
-          serverProperties: {},
-          mechanisms: Buffer.from('PLAIN'),
-          locales: Buffer.from('en_US'),
-        });
-        return wait(defs.ConnectionStartOk)()
-          .then(() => {
-            socket.end();
-          })
-          .then(succeed(done), fail(done));
-      },
-    ),
-  );
+  test('unexpected socket close', connectionTest((c, done) => {
+    c.open(OPEN_OPTS, kCallback(fail(done), succeed(done)));
+  }, (send, wait, done, socket) => {
+    send(defs.ConnectionStart, {
+      versionMajor: 0,
+      versionMinor: 9,
+      serverProperties: {},
+      mechanisms: Buffer.from('PLAIN'),
+      locales: Buffer.from('en_US'),
+    });
+    return wait(defs.ConnectionStartOk)()
+      .then(() => {
+        socket.end();
+      })
+      .then(succeed(done), fail(done));
+  }));
 });
 
 suite('Connection running', () => {
-  test(
-    'wrong frame on channel 0',
-    connectionTest(
-      (c, done) => {
-        c.on('error', succeed(done));
-        c.open(OPEN_OPTS);
-      },
-      (send, wait, done) => {
-        happy_open(send, wait)
-          .then(() => {
-            // there's actually nothing that would plausibly be sent to a
-            // just opened connection, so this is violating more than one
-            // rule. Nonetheless.
-            send(defs.ChannelOpenOk, {channelId: Buffer.from('')}, 0);
-          })
-          .then(wait(defs.ConnectionClose))
-          .then((_close) => {
-            send(defs.ConnectionCloseOk, {}, 0);
-          })
-          .then(succeed(done), fail(done));
-      },
-    ),
-  );
+  test('wrong frame on channel 0', connectionTest((c, done) => {
+    c.on('error', succeed(done));
+    c.open(OPEN_OPTS);
+  }, (send, wait, done) => {
+    happy_open(send, wait)
+      .then(() => {
+        // there's actually nothing that would plausibly be sent to a
+        // just opened connection, so this is violating more than one
+        // rule. Nonetheless.
+        send(defs.ChannelOpenOk, {channelId: Buffer.from('')}, 0);
+      })
+      .then(wait(defs.ConnectionClose))
+      .then((_close) => {
+        send(defs.ConnectionCloseOk, {}, 0);
+      })
+      .then(succeed(done), fail(done));
+  }));
 
-  test(
-    'unopened channel',
-    connectionTest(
-      (c, done) => {
-        c.on('error', succeed(done));
-        c.open(OPEN_OPTS);
-      },
-      (send, wait, done) => {
-        happy_open(send, wait)
-          .then(() => {
-            // there's actually nothing that would plausibly be sent to a
-            // just opened connection, so this is violating more than one
-            // rule. Nonetheless.
-            send(defs.ChannelOpenOk, {channelId: Buffer.from('')}, 3);
-          })
-          .then(wait(defs.ConnectionClose))
-          .then((_close) => {
-            send(defs.ConnectionCloseOk, {}, 0);
-          })
-          .then(succeed(done), fail(done));
-      },
-    ),
-  );
+  test('unopened channel', connectionTest((c, done) => {
+    c.on('error', succeed(done));
+    c.open(OPEN_OPTS);
+  }, (send, wait, done) => {
+    happy_open(send, wait)
+      .then(() => {
+        // there's actually nothing that would plausibly be sent to a
+        // just opened connection, so this is violating more than one
+        // rule. Nonetheless.
+        send(defs.ChannelOpenOk, {channelId: Buffer.from('')}, 3);
+      })
+      .then(wait(defs.ConnectionClose))
+      .then((_close) => {
+        send(defs.ConnectionCloseOk, {}, 0);
+      })
+      .then(succeed(done), fail(done));
+  }));
 
-  test(
-    'unexpected socket close',
-    connectionTest(
-      (c, done) => {
-        const errorAndClosed = latch(2, done);
-        c.on('error', succeed(errorAndClosed));
-        c.on('close', succeed(errorAndClosed));
-        c.open(
-          OPEN_OPTS,
-          kCallback(() => {
-            c.sendHeartbeat();
-          }, fail(errorAndClosed)),
-        );
-      },
-      (send, wait, done, socket) => {
-        happy_open(send, wait)
-          .then(wait())
-          .then(() => {
-            socket.end();
-          })
-          .then(succeed(done));
-      },
-    ),
-  );
+  test('unexpected socket close', connectionTest((c, done) => {
+    const errorAndClosed = latch(2, done);
+    c.on('error', succeed(errorAndClosed));
+    c.on('close', succeed(errorAndClosed));
+    c.open(OPEN_OPTS, kCallback(() => {
+      c.sendHeartbeat();
+    }, fail(errorAndClosed)));
+  }, (send, wait, done, socket) => {
+    happy_open(send, wait)
+      .then(wait())
+      .then(() => {
+        socket.end();
+      })
+      .then(succeed(done));
+  }));
 
-  test(
-    'connection.blocked',
-    connectionTest(
-      (c, done) => {
-        c.on('blocked', succeed(done));
-        c.open(OPEN_OPTS);
-      },
-      (send, wait, done, _socket) => {
-        happy_open(send, wait)
-          .then(() => {
-            send(defs.ConnectionBlocked, {reason: 'felt like it'}, 0);
-          })
-          .then(succeed(done));
-      },
-    ),
-  );
+  test('connection.blocked', connectionTest((c, done) => {
+    c.on('blocked', succeed(done));
+    c.open(OPEN_OPTS);
+  }, (send, wait, done, _socket) => {
+    happy_open(send, wait)
+      .then(() => {
+        send(defs.ConnectionBlocked, {reason: 'felt like it'}, 0);
+      })
+      .then(succeed(done));
+  }));
 
-  test(
-    'connection.unblocked',
-    connectionTest(
-      (c, done) => {
-        c.on('unblocked', succeed(done));
-        c.open(OPEN_OPTS);
-      },
-      (send, wait, done, _socket) => {
-        happy_open(send, wait)
-          .then(() => {
-            send(defs.ConnectionUnblocked, {}, 0);
-          })
-          .then(succeed(done));
-      },
-    ),
-  );
+  test('connection.unblocked', connectionTest((c, done) => {
+    c.on('unblocked', succeed(done));
+    c.open(OPEN_OPTS);
+  }, (send, wait, done, _socket) => {
+    happy_open(send, wait)
+      .then(() => {
+        send(defs.ConnectionUnblocked, {}, 0);
+      })
+      .then(succeed(done));
+  }));
 });
 
 suite('Connection close', () => {
-  test(
-    'happy',
-    connectionTest(
-      (c, done0) => {
-        const done = latch(2, done0);
-        c.on('close', done);
-        c.open(
-          OPEN_OPTS,
-          kCallback(
-            (_ok) => {
-              c.close(kCallback(succeed(done), fail(done)));
-            },
-            () => {},
-          ),
-        );
-      },
-      (send, wait, done) => {
-        happy_open(send, wait)
-          .then(wait(defs.ConnectionClose))
-          .then((_close) => {
-            send(defs.ConnectionCloseOk, {});
-          })
-          .then(succeed(done), fail(done));
-      },
-    ),
-  );
+  test('happy', connectionTest((c, done0) => {
+    const done = latch(2, done0);
+    c.on('close', done);
+    c.open(OPEN_OPTS, kCallback((_ok) => {
+      c.close(kCallback(succeed(done), fail(done)));
+    }, () => {}));
+  }, (send, wait, done) => {
+    happy_open(send, wait)
+      .then(wait(defs.ConnectionClose))
+      .then((_close) => {
+        send(defs.ConnectionCloseOk, {});
+      })
+      .then(succeed(done), fail(done));
+  }));
 
-  test(
-    'interleaved close frames',
-    connectionTest(
-      (c, done0) => {
-        const done = latch(2, done0);
-        c.on('close', done);
-        c.open(
-          OPEN_OPTS,
-          kCallback((_ok) => {
-            c.close(kCallback(succeed(done), fail(done)));
-          }, done),
-        );
-      },
-      (send, wait, done) => {
-        happy_open(send, wait)
-          .then(wait(defs.ConnectionClose))
-          .then((_f) => {
-            send(defs.ConnectionClose, {
-              replyText: 'Ha!',
-              replyCode: defs.constants.REPLY_SUCCESS,
-              methodId: 0,
-              classId: 0,
-            });
-          })
-          .then(wait(defs.ConnectionCloseOk))
-          .then((_f) => {
-            send(defs.ConnectionCloseOk, {});
-          })
-          .then(succeed(done), fail(done));
-      },
-    ),
-  );
+  test('interleaved close frames', connectionTest((c, done0) => {
+    const done = latch(2, done0);
+    c.on('close', done);
+    c.open(OPEN_OPTS, kCallback((_ok) => {
+      c.close(kCallback(succeed(done), fail(done)));
+    }, done));
+  }, (send, wait, done) => {
+    happy_open(send, wait)
+      .then(wait(defs.ConnectionClose))
+      .then((_f) => {
+        send(defs.ConnectionClose, {
+          replyText: 'Ha!',
+          replyCode: defs.constants.REPLY_SUCCESS,
+          methodId: 0,
+          classId: 0,
+        });
+      })
+      .then(wait(defs.ConnectionCloseOk))
+      .then((_f) => {
+        send(defs.ConnectionCloseOk, {});
+      })
+      .then(succeed(done), fail(done));
+  }));
 
-  test(
-    'server error close',
-    connectionTest(
-      (c, done0) => {
-        const done = latch(2, done0);
-        c.on('close', succeed(done));
-        c.on('error', succeed(done));
-        c.open(OPEN_OPTS);
-      },
-      (send, wait, done) => {
-        happy_open(send, wait)
-          .then((_f) => {
-            send(defs.ConnectionClose, {
-              replyText: 'Begone',
-              replyCode: defs.constants.INTERNAL_ERROR,
-              methodId: 0,
-              classId: 0,
-            });
-          })
-          .then(wait(defs.ConnectionCloseOk))
-          .then(succeed(done), fail(done));
-      },
-    ),
-  );
+  test('server error close', connectionTest((c, done0) => {
+    const done = latch(2, done0);
+    c.on('close', succeed(done));
+    c.on('error', succeed(done));
+    c.open(OPEN_OPTS);
+  }, (send, wait, done) => {
+    happy_open(send, wait)
+      .then((_f) => {
+        send(defs.ConnectionClose, {
+          replyText: 'Begone',
+          replyCode: defs.constants.INTERNAL_ERROR,
+          methodId: 0,
+          classId: 0,
+        });
+      })
+      .then(wait(defs.ConnectionCloseOk))
+      .then(succeed(done), fail(done));
+  }));
 
-  test(
-    'operator-intiated close',
-    connectionTest(
-      (c, done) => {
-        c.on('close', succeed(done));
-        c.on('error', fail(done));
-        c.open(OPEN_OPTS);
-      },
-      (send, wait, done) => {
-        happy_open(send, wait)
-          .then((_f) => {
-            send(defs.ConnectionClose, {
-              replyText: 'Begone',
-              replyCode: defs.constants.CONNECTION_FORCED,
-              methodId: 0,
-              classId: 0,
-            });
-          })
-          .then(wait(defs.ConnectionCloseOk))
-          .then(succeed(done), fail(done));
-      },
-    ),
-  );
+  test('operator-intiated close', connectionTest((c, done) => {
+    c.on('close', succeed(done));
+    c.on('error', fail(done));
+    c.open(OPEN_OPTS);
+  }, (send, wait, done) => {
+    happy_open(send, wait)
+      .then((_f) => {
+        send(defs.ConnectionClose, {
+          replyText: 'Begone',
+          replyCode: defs.constants.CONNECTION_FORCED,
+          methodId: 0,
+          classId: 0,
+        });
+      })
+      .then(wait(defs.ConnectionCloseOk))
+      .then(succeed(done), fail(done));
+  }));
 
-  test(
-    'double close',
-    connectionTest(
-      (c, done) => {
-        c.open(
-          OPEN_OPTS,
-          kCallback(() => {
-            c.close();
-            // NB no synchronisation, we do this straight away
-            assert.throws(() => {
-              c.close();
-            });
-            done();
-          }, done),
-        );
-      },
-      (send, wait, done) => {
-        happy_open(send, wait)
-          .then(wait(defs.ConnectionClose))
-          .then(() => {
-            send(defs.ConnectionCloseOk, {});
-          })
-          .then(succeed(done), fail(done));
-      },
-    ),
-  );
+  test('double close', connectionTest((c, done) => {
+    c.open(OPEN_OPTS, kCallback(() => {
+      c.close();
+      // NB no synchronisation, we do this straight away
+      assert.throws(() => {
+        c.close();
+      });
+      done();
+    }, done));
+  }, (send, wait, done) => {
+    happy_open(send, wait)
+      .then(wait(defs.ConnectionClose))
+      .then(() => {
+        send(defs.ConnectionCloseOk, {});
+      })
+      .then(succeed(done), fail(done));
+  }));
 });
 
 suite('heartbeats', () => {
@@ -403,50 +310,38 @@ suite('heartbeats', () => {
     heartbeat.UNITS_TO_MS = 1000;
   });
 
-  test(
-    'send heartbeat after open',
-    connectionTest(
-      (c, done) => {
-        completes(() => {
-          const opts = Object.create(OPEN_OPTS);
-          opts.heartbeat = 1;
-          // Don't leave the error waiting to happen for the next test, this
-          // confuses mocha awfully
-          c.on('error', () => {});
-          c.open(opts);
-        }, done);
-      },
-      (send, wait, done, socket) => {
-        let timer;
-        happy_open(send, wait)
-          .then(() => {
-            timer = setInterval(() => {
-              socket.write(HB_BUF);
-            }, heartbeat.UNITS_TO_MS);
-          })
-          .then(wait())
-          .then((hb) => {
-            if (hb === HEARTBEAT) done();
-            else done('Next frame after silence not a heartbeat');
-            clearInterval(timer);
-          });
-      },
-    ),
-  );
+  test('send heartbeat after open', connectionTest((c, done) => {
+    completes(() => {
+      const opts = Object.create(OPEN_OPTS);
+      opts.heartbeat = 1;
+      // Don't leave the error waiting to happen for the next test, this
+      // confuses mocha awfully
+      c.on('error', () => {});
+      c.open(opts);
+    }, done);
+  }, (send, wait, done, socket) => {
+    let timer;
+    happy_open(send, wait)
+      .then(() => {
+        timer = setInterval(() => {
+          socket.write(HB_BUF);
+        }, heartbeat.UNITS_TO_MS);
+      })
+      .then(wait())
+      .then((hb) => {
+        if (hb === HEARTBEAT) done();
+        else done('Next frame after silence not a heartbeat');
+        clearInterval(timer);
+      });
+  }));
 
-  test(
-    'detect lack of heartbeats',
-    connectionTest(
-      (c, done) => {
-        const opts = Object.create(OPEN_OPTS);
-        opts.heartbeat = 1;
-        c.on('error', succeed(done));
-        c.open(opts);
-      },
-      (send, wait, done, _socket) => {
-        happy_open(send, wait).then(succeed(done), fail(done));
-        // conspicuously not sending anything ...
-      },
-    ),
-  );
+  test('detect lack of heartbeats', connectionTest((c, done) => {
+    const opts = Object.create(OPEN_OPTS);
+    opts.heartbeat = 1;
+    c.on('error', succeed(done));
+    c.open(opts);
+  }, (send, wait, done, _socket) => {
+    happy_open(send, wait).then(succeed(done), fail(done));
+    // conspicuously not sending anything ...
+  }));
 });

--- a/test/data.js
+++ b/test/data.js
@@ -26,10 +26,7 @@ function chooseInt(a, b) {
 }
 
 function rangeInt(name, a, b) {
-  return label(
-    name,
-    asGenerator((_) => chooseInt(a, b)),
-  );
+  return label(name, asGenerator((_) => chooseInt(a, b)));
 }
 
 function toFloat32(i) {
@@ -51,24 +48,15 @@ function floatChooser(maxExp) {
 }
 
 function explicitType(t, underlying) {
-  return label(
-    t,
-    transform((n) => ({'!': t, value: n}), underlying),
-  );
+  return label(t, transform((n) => ({'!': t, value: n}), underlying));
 }
 
 // FIXME null, byte array, others?
 
 const Octet = rangeInt('octet', 0, 255);
-const ShortStr = label(
-  'shortstr',
-  transform((s) => s.substr(0, 255), arb.Str),
-);
+const ShortStr = label('shortstr', transform((s) => s.substr(0, 255), arb.Str));
 
-const LongStr = label(
-  'longstr',
-  transform((bytes) => Buffer.from(bytes), repeat(Octet)),
-);
+const LongStr = label('longstr', transform((bytes) => Buffer.from(bytes), repeat(Octet)));
 
 const UShort = rangeInt('short-uint', 0, 0xffff);
 const ULong = rangeInt('long-uint', 0, 0xffffffff);
@@ -79,26 +67,11 @@ const LongLong = rangeInt('longlong-int', Number.MIN_SAFE_INTEGER, Number.MAX_SA
 const Bit = label('bit', arb.Bool);
 const Double = label('double', asGenerator(floatChooser(308)));
 const Float = label('float', transform(toFloat32, floatChooser(38)));
-const Timestamp = label(
-  'timestamp',
-  transform((n) => ({'!': 'timestamp', value: n}), ULongLong),
-);
-const Decimal = label(
-  'decimal',
-  transform((args) => ({'!': 'decimal', value: {places: args[1], digits: args[0]}}), sequence(arb.UInt, Octet)),
-);
-const UnsignedByte = label(
-  'unsignedbyte',
-  transform((n) => ({'!': 'unsignedbyte', value: n}), Octet),
-);
-const UnsignedShort = label(
-  'unsignedshort',
-  transform((n) => ({'!': 'unsignedshort', value: n}), UShort),
-);
-const UnsignedInt = label(
-  'unsignedint',
-  transform((n) => ({'!': 'unsignedint', value: n}), ULong),
-);
+const Timestamp = label('timestamp', transform((n) => ({'!': 'timestamp', value: n}), ULongLong));
+const Decimal = label('decimal', transform((args) => ({'!': 'decimal', value: {places: args[1], digits: args[0]}}), sequence(arb.UInt, Octet)));
+const UnsignedByte = label('unsignedbyte', transform((n) => ({'!': 'unsignedbyte', value: n}), Octet));
+const UnsignedShort = label('unsignedshort', transform((n) => ({'!': 'unsignedshort', value: n}), UShort));
+const UnsignedInt = label('unsignedint', transform((n) => ({'!': 'unsignedint', value: n}), ULong));
 
 // Signed 8 bit int
 const Byte = rangeInt('byte', -128, 127);
@@ -113,72 +86,17 @@ const ExInt32 = explicitType('int32', Long);
 const ExLong = explicitType('long', LongLong);
 const ExInt64 = explicitType('int64', LongLong);
 
-const FieldArray = label(
-  'field-array',
-  recursive(() =>
-    arb.Array(
-      arb.Null,
-      LongStr,
-      ShortStr,
-      Octet,
-      UShort,
-      ULong,
-      ULongLong,
-      Byte,
-      Short,
-      Long,
-      LongLong,
-      ExByte,
-      ExInt8,
-      ExShort,
-      ExInt16,
-      ExInt,
-      ExInt32,
-      ExLong,
-      ExInt64,
-      Bit,
-      Float,
-      Double,
-      FieldTable,
-      FieldArray,
-    ),
-  ),
-);
+const FieldArray = label('field-array', recursive(() => arb.Array(
+  arb.Null, LongStr, ShortStr, Octet, UShort, ULong, ULongLong, Byte, Short, Long, LongLong,
+  ExByte, ExInt8, ExShort, ExInt16, ExInt, ExInt32, ExLong, ExInt64, Bit, Float, Double,
+  FieldTable, FieldArray,
+)));
 
-const FieldTable = label(
-  'table',
-  recursive(() =>
-    sized(
-      () => 5,
-      arb.Object(
-        arb.Null,
-        LongStr,
-        ShortStr,
-        Octet,
-        UShort,
-        ULong,
-        ULongLong,
-        Byte,
-        Short,
-        Long,
-        LongLong,
-        ExByte,
-        ExInt8,
-        ExShort,
-        ExInt16,
-        ExInt,
-        ExInt32,
-        ExLong,
-        ExInt64,
-        Bit,
-        Float,
-        Double,
-        FieldArray,
-        FieldTable,
-      ),
-    ),
-  ),
-);
+const FieldTable = label('table', recursive(() => sized(() => 5, arb.Object(
+  arb.Null, LongStr, ShortStr, Octet, UShort, ULong, ULongLong, Byte, Short, Long, LongLong,
+  ExByte, ExInt8, ExShort, ExInt16, ExInt, ExInt32, ExLong, ExInt64, Bit, Float, Double,
+  FieldArray, FieldTable,
+))));
 
 // Internal tests of our properties
 const domainProps = [
@@ -248,10 +166,7 @@ const defs = require('../lib/defs');
 function method(info) {
   const domain = sequence.apply(null, info.args.map(argtype));
   const names = info.args.map(name);
-  return label(
-    info.name,
-    transform((fieldVals) => ({id: info.id, fields: zipObject(fieldVals, names)}), domain),
-  );
+  return label(info.name, transform((fieldVals) => ({id: info.id, fields: zipObject(fieldVals, names)}), domain));
 }
 
 function properties(info) {
@@ -259,10 +174,7 @@ function properties(info) {
   types.unshift(ULongLong); // size
   const domain = sequence.apply(null, types);
   const names = info.args.map(name);
-  return label(
-    info.name,
-    transform((fieldVals) => ({id: info.id, size: fieldVals[0], fields: zipObject(fieldVals.slice(1), names)}), domain),
-  );
+  return label(info.name, transform((fieldVals) => ({id: info.id, size: fieldVals[0], fields: zipObject(fieldVals.slice(1), names)}), domain));
 }
 
 const methods = [];

--- a/test/frame.js
+++ b/test/frame.js
@@ -138,25 +138,16 @@ suite('Parsing', () => {
       .asTest({times: 20});
   }
 
-  test(
-    'Parse trace of methods',
-    testPartitioning((bufs) => bufs),
-  );
+  test('Parse trace of methods', testPartitioning((bufs) => bufs));
 
-  test(
-    "Parse concat'd methods",
-    testPartitioning((bufs) => [Buffer.concat(bufs)]),
-  );
+  test("Parse concat'd methods", testPartitioning((bufs) => [Buffer.concat(bufs)]));
 
-  test(
-    'Parse partitioned methods',
-    testPartitioning((bufs) => {
-      const full = Buffer.concat(bufs);
-      const onethird = Math.floor(full.length / 3);
-      const twothirds = 2 * onethird;
-      return [full.subarray(0, onethird), full.subarray(onethird, twothirds), full.subarray(twothirds)];
-    }),
-  );
+  test('Parse partitioned methods', testPartitioning((bufs) => {
+    const full = Buffer.concat(bufs);
+    const onethird = Math.floor(full.length / 3);
+    const twothirds = 2 * onethird;
+    return [full.subarray(0, onethird), full.subarray(onethird, twothirds), full.subarray(twothirds)];
+  }));
 });
 
 const FRAME_MAX_MAX = 4096 * 4;
@@ -176,31 +167,26 @@ const Content = transform(
 );
 
 suite('Content framing', () => {
-  test(
-    'Adhere to frame max',
-    forAll(Content, FrameMax)
-      .satisfy((content, max) => {
-        const input = inputs();
-        const frames = new Frames(input);
-        frames.frameMax = max;
-        frames.sendMessage(0, defs.BasicDeliver, content.method, defs.BasicProperties, content.header, content.body);
-        let _i = 0;
-        let largest = 0;
-        let frame = input.read();
-        while (frame) {
-          _i++;
-          if (frame.length > largest) largest = frame.length;
-          if (frame.length > max) {
-            return false;
-          }
-          frame = input.read();
-        }
-        // The ratio of frames to 'contents' should always be >= 2
-        // (one properties frame and at least one content frame); > 2
-        // indicates fragmentation. The largest is always, of course <= frame max
-        //console.log('Frames: %d; frames per message: %d; largest frame %d', _i, _i / t.length, largest);
-        return true;
-      })
-      .asTest(),
-  );
+  test('Adhere to frame max', forAll(Content, FrameMax).satisfy((content, max) => {
+    const input = inputs();
+    const frames = new Frames(input);
+    frames.frameMax = max;
+    frames.sendMessage(0, defs.BasicDeliver, content.method, defs.BasicProperties, content.header, content.body);
+    let _i = 0;
+    let largest = 0;
+    let frame = input.read();
+    while (frame) {
+      _i++;
+      if (frame.length > largest) largest = frame.length;
+      if (frame.length > max) {
+        return false;
+      }
+      frame = input.read();
+    }
+    // The ratio of frames to 'contents' should always be >= 2
+    // (one properties frame and at least one content frame); > 2
+    // indicates fragmentation. The largest is always, of course <= frame max
+    //console.log('Frames: %d; frames per message: %d; largest frame %d', _i, _i / t.length, largest);
+    return true;
+  }).asTest());
 });


### PR DESCRIPTION
The tests line breaking was overly aggressive so I have reformatted them. Unfortunately the aggressive line wrapping was enforced by biome so I have excluded the tests from formatting, and will explore other formatting options. I've found similar problems with prettier so will try [dtprint](https://dprint.dev)